### PR TITLE
Release 0.0.5

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,7 +1,7 @@
 package:
   name: autorelease
   # add ".dev0" for unreleased versions
-  version: "0.0.5.dev0"
+  version: "0.0.5"
 
 source:
   path: ../../

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 # * VERSION: base version (do not include .dev0, etc -- that's automatic)
 # * IS_RELEASE: whether this is a release
 VERSION = "0.0.5"
-IS_RELEASE = False
+IS_RELEASE = True
 
 DEV_NUM = 0  # always 0: we don't do public (pypi) .dev releases
 PRE_TYPE = ""  # a, b, or rc (although we rarely release such versions)


### PR DESCRIPTION
# autorelease 0.0.5

Fixes due to failed releases 0.0.3 and 0.0.4 (not released due to errors).

* Use Travis-CI stages to manage multiple stages of release process, with deployment and test thereof on testpypi [#5]
* Add (only partly tested) automatic creation of releases on GitHub (as a stage before final deployment to pyPI) [#8]

The `0.0.x` series is for experimental releases.