### PR TITLE
Release 0.0.6

### DIFF
--- a/autorelease/check_runners.py
+++ b/autorelease/check_runners.py
@@ -80,8 +80,10 @@ class DefaultCheckRunner(CheckRunner):
         parser.add_argument('--branch', type=str)
         opts = parser.parse_args()
         if opts.branch in self.release_branches:
+            print("Testing as release")
             tests = self.release_tests
         else:
+            print("Testing as nonrelease")
             tests = self.nonrelease_tests
         return tests
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,7 +1,7 @@
 package:
   name: autorelease
   # add ".dev0" for unreleased versions
-  version: "0.0.6.dev0"
+  version: "0.0.6"
 
 source:
   path: ../../

--- a/release_check.py
+++ b/release_check.py
@@ -5,6 +5,7 @@ import argparse
 
 import setup
 #import contact_map
+from packaging.version import Version
 from autorelease import DefaultCheckRunner, conda_recipe_version
 
 repo_path = '.'
@@ -15,7 +16,7 @@ versions = {
 }
 
 RELEASE_BRANCHES = ['stable']
-RELEASE_TAG = "v" + setup.PACKAGE_VERSION
+RELEASE_TAG = "v" + Version(setup.PACKAGE_VERSION).base_version
 
 if __name__ == "__main__":
     checker = DefaultCheckRunner(
@@ -27,7 +28,7 @@ if __name__ == "__main__":
     tests = checker.select_tests_from_sysargs()
 
     skip = []
-    skip = [checker.git_repo_checks.reasonable_desired_version]
+    #skip = [checker.git_repo_checks.reasonable_desired_version]
     for test in skip:
         skip_test = [t for t in tests if t[0] == test][0]
         tests.remove(skip_test)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 # * VERSION: base version (do not include .dev0, etc -- that's automatic)
 # * IS_RELEASE: whether this is a release
 VERSION = "0.0.6"
-IS_RELEASE = False
+IS_RELEASE = True
 
 DEV_NUM = 0  # always 0: we don't do public (pypi) .dev releases
 PRE_TYPE = ""  # a, b, or rc (although we rarely release such versions)


### PR DESCRIPTION
# autorelease 0.0.6

- Treat release tags as target for release-style testing

The `0.0.x` series is for experimental releases.