### PR TITLE
0.0.7

### DIFF
--- a/autorelease/git_repo_checks.py
+++ b/autorelease/git_repo_checks.py
@@ -8,6 +8,10 @@ class GitReleaseChecks(object):
         self.stable_branch = 'stable'
         self.dev_branch = 'master'
 
+    @staticmethod
+    def tag_from_version(version):
+        return "v" + str(version)
+
     def in_required_branch(self, required_branch='stable'):
         msg = ""
         current_branch = self.repo.active_branch.name
@@ -23,7 +27,7 @@ class GitReleaseChecks(object):
         # TODO: may be better to replace with regex for reusability
         return [vers.Version(v) for v in tag_versions]
 
-    def reasonable_desired_version(self, desired_version):
+    def reasonable_desired_version(self, desired_version, allow_equal=False):
         """
         Determine whether the desired version is a reasonable next version.
 
@@ -49,7 +53,13 @@ class GitReleaseChecks(object):
 
         update_str = str(max_version) + " -> " + str(desired_version)
 
-        if vers.Version(desired_version) < vers.Version(max_version):
+        v_desired = vers.Version(desired_version)
+        v_max = vers.Version(max_version)
+
+        if allow_equal and v_desired == v_max:
+            return ""
+
+        if v_desired < v_max:
             return ("Bad update: New version doesn't increase on last tag: "
                     + update_str + "\n")
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,7 +1,7 @@
 package:
   name: autorelease
   # add ".dev0" for unreleased versions
-  version: "0.0.7.dev0"
+  version: "0.0.7"
 
 source:
   path: ../../

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 # * VERSION: base version (do not include .dev0, etc -- that's automatic)
 # * IS_RELEASE: whether this is a release
 VERSION = "0.0.7"
-IS_RELEASE = False
+IS_RELEASE = True
 
 DEV_NUM = 0  # always 0: we don't do public (pypi) .dev releases
 PRE_TYPE = ""  # a, b, or rc (although we rarely release such versions)


### PR DESCRIPTION
# autorelease 0.0.7

- tags branches allow version equality (instead of requiring a version increase)

The `0.0.x` series is for experimental releases.