### PR TITLE
Release 0.0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,5 +92,7 @@ jobs:
         provider: pypi
         distributions: sdist bdist_wheel
         user: dwhswenson
+        on:
+            tags: true
         password:
           secure: "VnOfkKXPAGeUfWBQra+WISnmgQV1yiz1ZsOExSqzDvdnOkGZ3ToLYiNn0sEpPgzeeYOx8nkjWUYZ8e8b5oYmU1fQ+5AXJ/b8L5T463IMj0Qe4PL4leCfv9Rqn90NywUwGaYQseeOi8c1yB8XaMqWkBmwjFuHmk0B7PQ5DISWJa9NR9/ydGc5Rp8H0/z40eVkaNksNHZjEfr9FHMt1PFM3KWecH6WkGscSVii+B/dfAcDWOW/UKI1094ckQkGNxtOEOMR6NkiLqFgb6iCOUTfyypELRNHLb2mB5d+6/doy93uJbY9dgFgI0glUrr0Ira/Nn3KGObxezvl5noe9+quD10r4KTl338qINR6H/NGL/t62TDG+hXn7xpGJ9i6UjJt5xmZio22neo0UEchSSvERsAkgChYQJ4N2jA2WVVUKuH+REjDEARjWrhx1u8gMB4vQGjI+47nxEvRiSl/ICwLqHswLK2Y+uqdsDdKZZq5kLxgcIqeNxuUzNj2fAGSlEbZVJEMrEe01hVC44OSiz2mQ8ndaP/Nf6i/n+SHgE+oeIJasHbgyNHpfR36RFR5QsVKu0lKyQjjVsm7HtMzz+JnSfO1hfDK8n94AYjDyEP9T/4Hrwo4KAGKLER9rokyC3psrTWNiefYB1ODYJneTC6Uhyh9Sq/+RlNEtPdN8YjGQAE="

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,7 +1,7 @@
 package:
   name: autorelease
   # add ".dev0" for unreleased versions
-  version: "0.0.7.dev0"
+  version: "0.0.8"
 
 source:
   path: ../../

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ from setuptools import setup
 ####################### USER SETUP AREA #################################
 # * VERSION: base version (do not include .dev0, etc -- that's automatic)
 # * IS_RELEASE: whether this is a release
-VERSION = "0.0.7"
-IS_RELEASE = False
+VERSION = "0.0.8"
+IS_RELEASE = True
 
 DEV_NUM = 0  # always 0: we don't do public (pypi) .dev releases
 PRE_TYPE = ""  # a, b, or rc (although we rarely release such versions)


### PR DESCRIPTION
# autorelease 0.0.8

- add `deploy.on.tags: true` to pypi deploy

The `0.0.x` series is for experimental releases.