### PR TITLE
Allow version equal if event is cron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
 
 script:
   - python -c "import autorelease"
+  - echo $TRAVIS_EVENT
   - python release_check.py --branch ${TRAVIS_BRANCH} --event ${TRAVIS_EVENT}
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
 
 script:
   - python -c "import autorelease"
-  - python release_check.py --branch ${TRAVIS_BRANCH}
+  - python release_check.py --branch ${TRAVIS_BRANCH} --event ${TRAVIS_EVENT}
 
 after_success:
   - echo "success!"
@@ -91,6 +91,7 @@ jobs:
       deploy:
         provider: pypi
         distributions: sdist bdist_wheel
+        skip_cleanup: true  # need the readme.rst from the script stage
         user: dwhswenson
         on:
             tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ install:
 
 script:
   - python -c "import autorelease"
-  - echo $TRAVIS_EVENT
-  - python release_check.py --branch ${TRAVIS_BRANCH} --event ${TRAVIS_EVENT}
+  - echo $TRAVIS_EVENT_TYPE
+  - python release_check.py --branch ${TRAVIS_BRANCH} --event ${TRAVIS_EVENT_TYPE}
 
 after_success:
   - echo "success!"

--- a/autorelease/check_runners.py
+++ b/autorelease/check_runners.py
@@ -85,10 +85,12 @@ class DefaultCheckRunner(CheckRunner):
         # TODO: this can be cleaned up by separating reusable parts
         parser = argparse.ArgumentParser()
         parser.add_argument('--branch', type=str)
+        parser.add_argument('--event', type=str)
         opts = parser.parse_args()
         if opts.branch in self.release_branches:
             print("TESTING AS RELEASE")
-            allow_equal = opts.branch == self.tag_branch
+            allow_equal = (opts.event == 'cron'
+                           or opts.branch == self.tag_branch)
             tests = (self.tests
                      + self._reasonable_desired_version_test(allow_equal)
                      + self._is_release_tests(expected=True))


### PR DESCRIPTION
Should fix problem made that cron jobs on stable fail (because the version hasn't changed). Example: https://travis-ci.org/dwhswenson/autorelease/builds/296232667