### PR TITLE
New version.py and setup.cfg-based setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-version.py
+_installed_version.py
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/autorelease/__init__.py
+++ b/autorelease/__init__.py
@@ -1,3 +1,4 @@
+from . import version
 from .version_checks import VersionReleaseChecks
 from .git_repo_checks import GitReleaseChecks
 from .root_dir_checks import setup_is_release, readme_rst_exists

--- a/autorelease/version.py
+++ b/autorelease/version.py
@@ -116,7 +116,7 @@ def get_setup_version(default_version, directory, filename="setup.cfg"):
     version = default_version
     conf = get_setup_cfg(directory, filename)
     try:
-        version = conf['metadata']['version']
+        version = conf.get('metadata', 'version')
     except KeyError:
         pass  # version (or metadata) not defined in setup.cfg
     except TypeError:

--- a/autorelease/version.py
+++ b/autorelease/version.py
@@ -1,0 +1,131 @@
+# This file vendored from Autorelease
+import os
+import subprocess
+
+try:
+    from configparser import ConfigParser
+except ImportError:
+    from ConfigParser import ConfigParser  # py2
+
+try:
+    from ._installed_version import _installed_version
+    from ._installed_version import _installed_git_hash
+    from ._installed_version import _version_setup_depth
+except ImportError:
+    _installed_version = "Unknown"
+    _installed_git_hash = "Unknown"
+    _version_setup_depth = 0
+
+
+def get_git_version():
+    """
+    Return the git hash as a string.
+
+    Apparently someone got this from numpy's setup.py. It has since been
+    modified a few times.
+    """
+    # Return the git revision as a string
+    # copied from numpy setup.py
+    def _minimal_ext_cmd(cmd):
+        # construct minimal environment
+        env = {}
+        for k in ['SYSTEMROOT', 'PATH']:
+            v = os.environ.get(k)
+            if v is not None:
+                env[k] = v
+        # LANGUAGE is used on win32
+        env['LANGUAGE'] = 'C'
+        env['LANG'] = 'C'
+        env['LC_ALL'] = 'C'
+        with open(os.devnull, 'w') as err_out:
+            out = subprocess.Popen(cmd,
+                                   stdout=subprocess.PIPE,
+                                   stderr=err_out, # maybe debug later?
+                                   env=env).communicate()[0]
+        return out
+
+    try:
+        git_dir = os.path.dirname(os.path.realpath(__file__))
+        out = _minimal_ext_cmd(['git', '-C', git_dir, 'rev-parse', 'HEAD'])
+        GIT_REVISION = out.strip().decode('ascii')
+    except OSError:
+        GIT_REVISION = 'Unknown'
+
+    return GIT_REVISION
+
+def _find_rel_path_for_file(depth, filename):
+    rel_directory = None
+    if depth == 0:
+        rel_directory = '.'
+    elif depth >= 1:
+        rel_directory = os.sep.join(['..'] * depth)
+    else:
+        my_dir = os.path.dirname(os.path.abspath(__file__))
+        rel_directory_arr = []
+        while not rel_directory:
+            expected_dir = os.path.join(*rel_directory_arr) \
+                    if rel_directory_arr else '.'
+            expected = os.path.join(expected_dir, filename)
+            if os.path.isfile(expected):
+                rel_directory = expected_dir
+            else:
+                rel_directory_arr.append('..')
+
+            if len(rel_directory_arr) > len(my_dir.split(os.sep)):
+                rel_directory_arr = []
+                break
+
+    if rel_directory:
+        return os.path.join(rel_directory, filename)
+    else:
+        return None
+
+
+def get_setup_cfg(directory, filename="setup.cfg"):
+    """Load the setup.cfg as a dict-of-dict.
+
+    Parameters
+    ----------
+    directory : str
+        directory for setup.cfg, relative to cwd; default '.'
+    filename : str
+        filename for setup.cfg; default 'setup.cfg'
+    """
+    if isinstance(directory, int):
+        setup_cfg = os.path.normpath(_find_rel_path_for_file(directory,
+                                                             filename))
+    else:
+        setup_cfg = os.path.join(directory, filename)
+
+    conf = None
+    if os.path.exists(setup_cfg):
+        conf = ConfigParser()
+        conf.read(setup_cfg)
+
+    return conf
+
+
+def get_setup_version(default_version, directory, filename="setup.cfg"):
+    version = default_version
+    conf = get_setup_cfg(directory, filename)
+    try:
+        version = conf['metadata']['version']
+    except KeyError:
+        pass  # version (or metadata) not defined in setup.cfg
+    except TypeError:
+        pass  # no setup.cfg found
+    return version
+
+
+short_version = get_setup_version(_installed_version, directory='..')
+_git_version = get_git_version()
+_is_repo = (_git_version != '' and _git_version != "Unknown")
+
+if _is_repo:
+    git_hash = _git_version
+    full_version = short_version + "+g" + _git_version[:7]
+    version = full_version
+else:
+    git_hash = "Unknown"
+    full_version = short_version + "+g" + _installed_git_hash[:7] + '.install'
+    version = short_version

--- a/autorelease/version.py
+++ b/autorelease/version.py
@@ -53,6 +53,26 @@ def get_git_version():
 
     return GIT_REVISION
 
+def _seek_parent_dirs_for_file(filename):
+    rel_directory = None
+    my_dir = os.path.dirname(os.path.abspath(__file__))
+    rel_directory_arr = []
+    while not rel_directory:
+        expected_dir = os.path.join(*rel_directory_arr) \
+                if rel_directory_arr else '.'
+        expected = os.path.join(expected_dir, filename)
+        if os.path.isfile(expected):
+            rel_directory = expected_dir
+        else:
+            rel_directory_arr.append('..')
+
+        if len(rel_directory_arr) > len(my_dir.split(os.sep)):
+            rel_directory_arr = []
+            break
+
+    return rel_directory
+
+
 def _find_rel_path_for_file(depth, filename):
     rel_directory = None
     if depth == 0:
@@ -60,20 +80,7 @@ def _find_rel_path_for_file(depth, filename):
     elif depth >= 1:
         rel_directory = os.sep.join(['..'] * depth)
     else:
-        my_dir = os.path.dirname(os.path.abspath(__file__))
-        rel_directory_arr = []
-        while not rel_directory:
-            expected_dir = os.path.join(*rel_directory_arr) \
-                    if rel_directory_arr else '.'
-            expected = os.path.join(expected_dir, filename)
-            if os.path.isfile(expected):
-                rel_directory = expected_dir
-            else:
-                rel_directory_arr.append('..')
-
-            if len(rel_directory_arr) > len(my_dir.split(os.sep)):
-                rel_directory_arr = []
-                break
+        rel_directory = _seek_parent_dirs_for_file(filename)
 
     if rel_directory:
         return os.path.join(rel_directory, filename)

--- a/autorelease/version.py
+++ b/autorelease/version.py
@@ -3,9 +3,10 @@ import os
 import subprocess
 
 try:
-    from configparser import ConfigParser
+    from configparser import ConfigParser, NoSectionError, NoOptionError
 except ImportError:
-    from ConfigParser import ConfigParser  # py2
+    # py2
+    from ConfigParser import ConfigParser, NoSectionError, NoOptionError
 
 try:
     from ._installed_version import _installed_version
@@ -117,10 +118,10 @@ def get_setup_version(default_version, directory, filename="setup.cfg"):
     conf = get_setup_cfg(directory, filename)
     try:
         version = conf.get('metadata', 'version')
-    except KeyError:
+    except (NoSectionError, NoOptionError):
         pass  # version (or metadata) not defined in setup.cfg
-    except TypeError:
-        pass  # no setup.cfg found
+    except AttributeError:
+        pass  # no setup.cfg found (conf is None)
     return version
 
 

--- a/release_check.py
+++ b/release_check.py
@@ -7,16 +7,18 @@ import setup
 #import contact_map
 from packaging.version import Version
 from autorelease import DefaultCheckRunner, conda_recipe_version
+from autorelease.version import get_setup_version
 
 repo_path = '.'
+SETUP_VERSION = get_setup_version(None, directory='.')
 versions = {
     #'package': contact_map.version.version,
-    'setup.py': setup.PACKAGE_VERSION,
+    'setup.py': SETUP_VERSION,
     'conda-recipe': conda_recipe_version('devtools/conda-recipe/meta.yaml'),
 }
 
 RELEASE_BRANCHES = ['stable']
-RELEASE_TAG = "v" + Version(setup.PACKAGE_VERSION).base_version
+RELEASE_TAG = "v" + Version(SETUP_VERSION).base_version
 
 if __name__ == "__main__":
     checker = DefaultCheckRunner(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,43 @@
+[metadata]
+name = autorelease
+version = 0.0.15.dev0
+# version should end in .dev0 if this isn't to be released
+short_description = Tools to keep the release process clean.
+description = file: README.md
+description_content_type = text/markdown
+license = MIT
+url = "http://github.com/dwhswenson/autorelease"
+classifiers = 
+    Development Status :: 4 - Beta
+    Environment :: Console
+    Environment :: MacOS X
+    Environment :: Win32 (MS Windows)
+    Intended Audience :: Developers
+    License :: OSI Approved :: MIT License
+    Natural Language :: English
+    Operating System :: MacOS :: MacOS X
+    Operating System :: Microsoft :: Windows
+    Operating System :: POSIX
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Topic :: Software Development :: Testing
+
+[options]
+install_requires =
+    packaging
+    pyyaml
+    gitpython
+    future
+    requests
+packages = find:
+# scripts =  # TODO: this is where I'll put the bash scripts
+
+[options.entry_points]
+console_scripts = 
+    autorelease-release = autorelease.scripts.release:main
+    write-release-notes = autorelease.scripts.write_release_notes:main
+
 [bdist_wheel]
 universal=1

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ class VersionPyFinder(object):
             def visit_ImportFrom(self, node):
                 if node.module == self.import_name:
                     replacement = ast.Raise(exc=ast.Call(
-                        ast.Name(id='ImportError', ctx=ast.Load()),
+                        func=ast.Name(id='ImportError', ctx=ast.Load()),
                         args=[],
                         keywords=[],
                     ), cause=None)
@@ -113,11 +113,11 @@ def write_installed_version_py(filename="_installed_version.py",
     my_dir = os.path.abspath(os.path.dirname(__file__))
     conf = get_setup_cfg(directory=my_dir, filename='setup.cfg')
     # conf = get_setup_cfg(directory=my_dir, filename='new_setup.cfg')
-    version = conf['metadata']['version']
+    version = conf.get('metadata', 'version')
     git_rev = get_git_version()
 
     if src_dir is None:
-        src_dir = conf['metadata']['name']
+        src_dir = conf.get('metadata', 'name')
 
     with open (os.path.join(src_dir, filename), 'w') as f:
         f.write(content.format(vers=version, git=git_rev, depth=depth))


### PR DESCRIPTION
This is a major update to how Autorelease functions. It contains two major changes

1. A standard `version.py` to be vendored into other projects. Previously, we wrote `version.py` from the `setup.py` script. However, that `version.py` was somewhat limited in how well it could keep up to date in a developer install (it would correctly report git hashes, but not version number updates).

2. A new `setup.py` to be vendored into other projects, without the need to change it. Previously, the `setup.py` combined sections that were to be copied verbatim with sections to be changed by the user. Now everything to be changed by the user has move to `setup.cfg`.

Note that if a user wants to use the new `setup.py`, they must also use the new `version.py`. However, if a user wants to use the `version.py` without the new `setup.py`, that's fine. They only need to ensure that they write a `_installed_version.py` with the same 3 lines as our setup.py does.