### PR TITLE
Scripts to improve testpypi integration

### DIFF
--- a/autorelease/scripts/bump_dev_version.py
+++ b/autorelease/scripts/bump_dev_version.py
@@ -1,0 +1,69 @@
+import argparse
+try:
+    from configparser import ConfigParser, NoSectionError, NoOptionError
+except ImportError:
+    # py2
+    from ConfigParser import ConfigParser, NoSectionError, NoOptionError
+
+from packaging.version import Version
+import requests
+
+def get_latest_pypi(package, index="https://test.pypi.org/pypi"):
+    url = "/".join([index, package, 'json'])
+    req = requests.get(url)
+    version = req.json()['info']['version']
+    return version
+
+def _strip_dev(version_str):
+    version = Version(version_str)  # to normalize
+    return str(version).split('.dev')[0]
+
+def bump_dev_version(version_str):
+    version = Version(version_str)
+    if version.is_devrelease:
+        dev_str = ".dev" + str(version.dev + 1)
+        v_base, _ = str(version).split('.dev')
+        out_v = v_base + dev_str
+        pass
+    else:
+        out_v = version.public + ".dev0"
+    return out_v
+
+def select_version(v_pypi, v_setup):
+    vv_pypi = _strip_dev(v_pypi)
+    vv_setup = _strip_dev(v_setup)
+    if Version(vv_setup) > Version(vv_pypi):
+        return v_setup
+    elif Version(vv_setup) == Version(vv_pypi):
+        return v_pypi
+    else:
+        raise RuntimeError("Why does pypi have a newer version than setup?")
+
+def make_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--index", type=str,
+                        default="https://test.pypi.org/pypi",
+                        help="pypi index to search for versions")
+    parser.add_argument("-c", "--conf", type=str, default="setup.cfg",
+                        help="setup.cfg file to use")
+    parser.add_argument("-o", "--output", type=str,
+                        help="output file; defaults to same as input")
+    return parser
+
+def main():
+    parser = make_parser()
+    opts = parser.parse_args()
+    output = opts.conf if opts.output is None else opts.output
+    conf = ConfigParser()
+    conf.read(opts.conf)
+    v_setup = conf.get('metadata', 'version')
+    package = conf.get('metadata', 'name')
+    v_pypi = get_latest_pypi(package, opts.index)
+    version_to_bump = select_version(v_pypi, v_setup)
+    new_version = bump_dev_version(version_to_bump)
+    conf.set('metadata', 'version', new_version)
+    with open(output, 'w') as f:
+        conf.write(f)
+
+if __name__ == "__main__":
+    main()

--- a/autorelease/shell/wait-for-testpypi
+++ b/autorelease/shell/wait-for-testpypi
@@ -1,11 +1,13 @@
 #!/bin/bash
 
+# Usage: takes setup.py as input (NOT setup.cfg!)
+
 SETUP_PY=$1
 
 VERSION=`python $SETUP_PY --version`
 PROJECT=`python $SETUP_PY --name`
 
-echo "Searching test.pypi for  $VERSION"
+echo "Searching test.pypi for $VERSION"
 
 MISSING_VERSION=true
 while $MISSING_VERSION; do

--- a/autorelease/shell/wait-for-testpypi
+++ b/autorelease/shell/wait-for-testpypi
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+SETUP_PY=$1
+
+VERSION=`python $SETUP_PY --version`
+PROJECT=`python $SETUP_PY --name`
+
+echo "Searching test.pypi for  $VERSION"
+
+MISSING_VERSION=true
+while $MISSING_VERSION; do
+    pip_results=`pip search -i https://test.pypi.org/pypi $PROJECT`
+    pip search -i https://test.pypi.org/pypi $PROJECT
+    #echo $pip_results
+    grepped=`echo $pip_results | grep $PROJECT`
+    #echo "Grepped:" $grepped
+    if [ -n "$grepped" ]; then
+        MISSING_VERSION=false
+    else
+        echo "Looking for $PROJECT $VERSION"
+        echo "Found: $grepped ..."
+        echo "Waiting 5 seconds for the version to register"
+        sleep 5
+    fi
+done

--- a/autorelease/tests/test_bump_dev_version.py
+++ b/autorelease/tests/test_bump_dev_version.py
@@ -1,0 +1,24 @@
+import pytest
+from autorelease.scripts.bump_dev_version import *
+
+def test_make_parser():
+    parser = make_parser()
+    opts = parser.parse_args([])
+    assert opts.index == "https://test.pypi.org/pypi"
+    assert opts.conf == "setup.cfg"
+    assert opts.output is None
+
+@pytest.mark.parametrize("v_pypi, v_setup, expected", [
+    ("1.0", "1.1", "1.1"),
+    ("1.0.dev0", "1.0", "1.0.dev0"),
+    ("1.0.rc0", "1.0", "1.0"),
+])
+def test_select_version(v_pypi, v_setup, expected):
+    assert select_version(v_pypi, v_setup) == expected
+
+
+@pytest.mark.parametrize("version_str, expected", [
+    ("1.0", "1.0.dev0"), ("1.0.dev0", "1.0.dev1"),
+])
+def test_bump_dev_version(version_str, expected):
+    assert bump_dev_version(version_str) == expected

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,9 @@ name = autorelease
 version = 0.0.17.dev0
 # version should end in .dev0 if this isn't to be released
 short_description = Tools to keep the release process clean.
-description = file: README.md
-description_content_type = text/markdown
+description = Tools to keep the release process clean.
+long_description = file: README.md
+long_description_content_type = text/markdown
 license = MIT
 url = "http://github.com/dwhswenson/autorelease"
 classifiers = 
@@ -33,7 +34,8 @@ install_requires =
     requests
     python-dateutil
 packages = find:
-scripts = ['autorelease/shell/wait-for-testpypi']
+scripts =
+    autorelease/shell/wait-for-testpypi
 
 [options.entry_points]
 console_scripts = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,12 +32,13 @@ install_requires =
     future
     requests
 packages = find:
-# scripts =  # TODO: this is where I'll put the bash scripts
+scripts = ['autorelease/shell/wait-for-testpypi']
 
 [options.entry_points]
 console_scripts = 
     autorelease-release = autorelease.scripts.release:main
     write-release-notes = autorelease.scripts.write_release_notes:main
+    bump-dev-version = autorelease.scripts.bump_dev_version:main
 
 [bdist_wheel]
 universal=1

--- a/travis_stages/deploy_pypi.yml
+++ b/travis_stages/deploy_pypi.yml
@@ -4,16 +4,12 @@ jobs:
       # This stage runs when a version-labelled tag is made. It deploys the
       # package to PyPI.
       if: tag =~ ^v[0-9]+\.
-      addons:
-        apt_packages:
-          - pandoc
       install: skip
-      script:
-          - pandoc --from=markdown --to=rst --output=README.rst README.md
+      script: skip
       deploy:
         provider: pypi
         distributions: sdist bdist_wheel
-        skip_cleanup: true  # need the readme.rst from the script stage
+        #skip_cleanup: true  # need the readme.rst from the script stage
         user: $TWINE_USERNAME
         on:
             tags: true

--- a/travis_stages/deploy_testpypi.yml
+++ b/travis_stages/deploy_testpypi.yml
@@ -5,8 +5,10 @@ jobs:
       # deployment to testpypi works.
       if: "(branch = stable) and (type = pull_request)"
       install:
-        - pip install twine
+        - pip install twine #autorelease
+        - rehash
       script: 
-        # TODO: add the rewrite-cfg to dev script
+        #- bump-dev-version  # comes from autorelease
+        - python setup.py --version
         - python setup.py sdist bdist_wheel
         - twine upload --repository-url https://test.pypi.org/legacy/ dist/*

--- a/travis_stages/deploy_testpypi.yml
+++ b/travis_stages/deploy_testpypi.yml
@@ -4,12 +4,9 @@ jobs:
       # This stage runs when you make a PR to stable. It tests that the
       # deployment to testpypi works.
       if: "(branch = stable) and (type = pull_request)"
-      addons:
-        apt_packages:
-          - pandoc
       install:
         - pip install twine
       script: 
-        - pandoc --from=markdown --to=rst --output=README.rst README.md
+        # TODO: add the rewrite-cfg to dev script
         - python setup.py sdist bdist_wheel
         - twine upload --repository-url https://test.pypi.org/legacy/ dist/*

--- a/travis_stages/test_testpypi.yml
+++ b/travis_stages/test_testpypi.yml
@@ -7,6 +7,7 @@ jobs:
       if: "(branch = stable) and (type = pull_request)"
       install:
         - export PROJECT=`python setup.py --name`
+        # TODO: add the script to wait for the correct version
         - pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple $PROJECT
       script: |
           if [ -n "$AUTORELEASE_TEST_TESTPYPI" ]; then

--- a/travis_stages/test_testpypi.yml
+++ b/travis_stages/test_testpypi.yml
@@ -6,8 +6,10 @@ jobs:
       # works.
       if: "(branch = stable) and (type = pull_request)"
       install:
+        #- pip install autorelease
+        - rehash
+        #- wait-for-testpypi setup.py
         - export PROJECT=`python setup.py --name`
-        # TODO: add the script to wait for the correct version
         - pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple $PROJECT
       script: |
           if [ -n "$AUTORELEASE_TEST_TESTPYPI" ]; then


### PR DESCRIPTION
A few things here:

- [x] No longer require pandoc, since pypi *can* read markdown
- [x] New `bump-dev-version` script that will bump to the first dev version not released on testpypi. The idea is that we *always* release dev versions on testpypi, but *never* release them on the real pypi. This way we no longer have the annoying patch-version-skipping every time something goes wrong on testpypi.
- [x] New `wait-for-testpypi` script that waits until the desired version shows up in the `pip search` command. Previously, we'd occasionally download the OLD version because the newly-uploaded package hadn't registered yet. That could lead to confusion.

Note that the `wait-for-testpypi` script will take any matching version, so you might get release candidates instead of final, or you might get a previous dev if you have to bump multiple times. In any case, the test-testpypi stage can always be rerun without problem.