### PR TITLE
Autorelease 0.1.0

### DIFF
--- a/autorelease-travis.yml
+++ b/autorelease-travis.yml
@@ -1,6 +1,6 @@
-# AUTORELEASE v0.0.18
+# AUTORELEASE v0.1.0
 import:
-    - dwhswenson/autorelease:travis_stages/deploy_testpypi.yml@v0.0.18
-    - dwhswenson/autorelease:travis_stages/cut_release.yml@v0.0.18
-    - dwhswenson/autorelease:travis_stages/deploy_pypi.yml@v0.0.18
-    - dwhswenson/autorelease:travis_stages/test_testpypi.yml@v0.0.18
+    - dwhswenson/autorelease:travis_stages/deploy_testpypi.yml@v0.1.0
+    - dwhswenson/autorelease:travis_stages/cut_release.yml@v0.1.0
+    - dwhswenson/autorelease:travis_stages/deploy_pypi.yml@v0.1.0
+    - dwhswenson/autorelease:travis_stages/test_testpypi.yml@v0.1.0

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,7 +1,7 @@
 package:
   name: autorelease
   # add ".dev0" for unreleased versions
-  version: "0.0.18"
+  version: "0.1.0"
 
 source:
   path: ../../

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = autorelease
-version = 0.0.18
+version = 0.1.0
 # version should end in .dev0 if this isn't to be released
 short_description = Tools to keep the release process clean.
 description = Tools to keep the release process clean.

--- a/travis_stages/deploy_testpypi.yml
+++ b/travis_stages/deploy_testpypi.yml
@@ -6,10 +6,10 @@ jobs:
       if: "(branch = stable) and (type = pull_request)"
       install:
         - pip install twine
-        #- pip install autorelease
+        - pip install autorelease
         # this is for debugging anything in autorelease used here (change
         # the branch tag to whatever is needed)
-        - pip install git+https://github.com/dwhswenson/autorelease.git@release-0.0.18#egg=autorelease
+        #- pip install git+https://github.com/dwhswenson/autorelease.git@release-0.0.18#egg=autorelease
         - hash -r
       script: 
         - bump-dev-version  # comes from autorelease

--- a/travis_stages/test_testpypi.yml
+++ b/travis_stages/test_testpypi.yml
@@ -6,10 +6,10 @@ jobs:
       # works.
       if: "(branch = stable) and (type = pull_request)"
       install:
-        #- pip install autorelease
+        - pip install autorelease
         # this is for debugging anything in autorelease used here (change
         # the branch tag to whatever is needed)
-        - pip install git+https://github.com/dwhswenson/autorelease.git@release-0.0.18#egg=autorelease
+        #- pip install git+https://github.com/dwhswenson/autorelease.git@release-0.0.18#egg=autorelease
         - hash -r
         - wait-for-testpypi
         - export PROJECT=`python setup.py --name`


### PR DESCRIPTION
This is the public-ready version of Autorelease. Thanks to the ability to import Travis configs, this can now finally be the project I've wanted it to be -- easily used by different projects, my own or those of others.

More docs still need to be written, but the main idea is that you keep a particular branch `stable` from which you do your releases. When you want to do a release, you make a PR against `stable`. It runs tests and a test deployment; when merged it cuts a GitHub release and pushes the real deployment. All without you needing to worry about it!

Basic setup process is:

* vendor the `setup.py` and `version.py` scripts from here
* write your `setup.cfg`
* add a few environment variables to your Travis script: `AUTORELEASE_TOKEN` (a GitHub personal access token) and pypi credentials $TWINE_USERNAME and $TWINE_PASSWORD (should be the same for both pypi and testpypi)
* import `dwhswenson/autorelease:autorelease-travis.yml@v0.1.0` in your Travis script
* optionally, write a small script to check that your branch/version behavior is correct

(Note: Version 0.1.0 is essentially a repackaging of 0.0.18, so there is no changelog here.)