### PR TITLE
Fix issues with less-than-perfect version tags

### DIFF
--- a/autorelease/git_repo_checks.py
+++ b/autorelease/git_repo_checks.py
@@ -45,7 +45,16 @@ class GitReleaseChecks(object):
         # this takes the version (before the '_') and drops the preceding v
         tag_versions = [t.name.split('_')[0][1:] for t in self.repo.tags]
         # TODO: may be better to replace with regex for reusability
-        return [vers.Version(v) for v in tag_versions]
+        versions = []
+        for version in tag_versions:
+            try:
+                v = vers.Version(version)
+            except vers.InvalidVersion:
+                pass
+            else:
+                versions.append(v)
+        return versions
+        # return [vers.Version(v) for v in tag_versions]
 
     def reasonable_desired_version(self, desired_version, allow_equal=False,
                                   allow_patch_skip=False):
@@ -69,8 +78,9 @@ class GitReleaseChecks(object):
             # no tags yet, and legal version is legal!
             return ""
         max_version = max(self._versions_from_tags()).base_version
-        (old_major, old_minor, old_patch) = \
-                map(int, str(max_version).split('.'))
+        parts = list(map(int, str(max_version).split('.')))
+        parts += [0] * (3 - len(parts))
+        old_major, old_minor, old_patch = parts
 
         update_str = str(max_version) + " -> " + str(desired_version)
 

--- a/autorelease/utils.py
+++ b/autorelease/utils.py
@@ -3,7 +3,7 @@ import re
 
 def conda_recipe_version(recipe_file):
     with open(recipe_file) as f:
-        dct = yaml.load(f.read())
+        dct = yaml.load(f.read(), Loader=yaml.FullLoader)
     return dct['package']['version']
 
 def github_url_to_owner_repo(url):

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,8 @@ def write_installed_version_py(filename="_installed_version.py",
     version = conf.get('metadata', 'version')
     git_rev = get_git_version()
 
+    # TODO: shouldn't vwe just use the directory found by the
+    # VersionPyFinder?
     if src_dir is None:
         src_dir = conf.get('metadata', 'name')
 


### PR DESCRIPTION
This adds support for cases where users aren't using version tags "perfectly" (according to Autorelease).

* Allow shorter version labels (e.g., `v1.0` instead of `v1.0.0`)
* Ignore tags that can't be parsed as versions

Also silences a pyyaml warning when loading conda recipes.