### PR TITLE
Fixes for problems found by OpenPathSampling

### DIFF
--- a/autorelease-travis.yml
+++ b/autorelease-travis.yml
@@ -1,6 +1,6 @@
 # AUTORELEASE v0.1.1.dev0
 import:
-    - dwhswenson/autorelease:travis_stages/deploy_testpypi.yml@master
-    - dwhswenson/autorelease:travis_stages/cut_release.yml@master
-    - dwhswenson/autorelease:travis_stages/deploy_pypi.yml@master
-    - dwhswenson/autorelease:travis_stages/test_testpypi.yml@master
+    - dwhswenson/autorelease:travis_stages/deploy_testpypi.yml@ops_fixes
+    - dwhswenson/autorelease:travis_stages/cut_release.yml@ops_fixes
+    - dwhswenson/autorelease:travis_stages/deploy_pypi.yml@ops_fixes
+    - dwhswenson/autorelease:travis_stages/test_testpypi.yml@ops_fixes

--- a/autorelease/scripts/bump_dev_version.py
+++ b/autorelease/scripts/bump_dev_version.py
@@ -1,10 +1,14 @@
 import argparse
 import time
+
 try:
     from configparser import ConfigParser, NoSectionError, NoOptionError
 except ImportError:
     # py2
     from ConfigParser import ConfigParser, NoSectionError, NoOptionError
+
+
+from json import JSONDecodeError
 
 from packaging.version import Version
 import requests
@@ -12,10 +16,10 @@ import requests
 def get_latest_pypi(package, index="https://test.pypi.org/pypi"):
     url = "/".join([index, package, 'json'])
     req = requests.get(url)
-    if req.ok:
+    try:
         version = max([Version(v) for v in req.json()['releases'].keys()])
-    else:
-        # probably 404'd because it isn't there
+    except JSONDecodeError:
+        # couldn't find a version, so we're okay
         version = "0.0.0.dev0"
     return str(version)
 

--- a/autorelease/scripts/bump_dev_version.py
+++ b/autorelease/scripts/bump_dev_version.py
@@ -12,7 +12,11 @@ import requests
 def get_latest_pypi(package, index="https://test.pypi.org/pypi"):
     url = "/".join([index, package, 'json'])
     req = requests.get(url)
-    version = max([Version(v) for v in req.json()['releases'].keys()])
+    if req.ok:
+        version = max([Version(v) for v in req.json()['releases'].keys()])
+    else:
+        # probably 404'd because it isn't there
+        version = "0.0.0.dev0"
     return str(version)
 
 def _strip_dev(version_str):

--- a/setup.py
+++ b/setup.py
@@ -76,11 +76,7 @@ class VersionPyFinder(object):
 
             def visit_ImportFrom(self, node):
                 if node.module == self.import_name:
-                    replacement = ast.Raise(exc=ast.Call(
-                        func=ast.Name(id='ImportError', ctx=ast.Load()),
-                        args=[],
-                        keywords=[],
-                    ), cause=None)
+                    replacement = ast.parse("raise ImportError()").body[0]
                     return ast.copy_location(replacement, node)
                 else:
                     return node

--- a/travis_stages/cut_release.yml
+++ b/travis_stages/cut_release.yml
@@ -5,9 +5,14 @@ jobs:
       # release based on the current stable branch and the release notes
       # from the last PR merged into stable.
       if: "(branch = stable) and (not type in (pull_request, cron))"
+      before_install: skip
       install:
         - pip install autorelease
+      before_script: skip
       script:
         - VERSION=`python setup.py --version`
         - PROJECT=`python setup.py --name`
         - autorelease-release --project $PROJECT --version $VERSION --token $AUTORELEASE_TOKEN
+      after_success: skip
+      after_failure: skip
+      after_script: skip

--- a/travis_stages/deploy_pypi.yml
+++ b/travis_stages/deploy_pypi.yml
@@ -9,7 +9,7 @@ jobs:
       before_script: skip
       before_cache: skip
       script: skip
-      after_success: skip
+      after_success: 'true'
       # before_deploy is allowed
       deploy:
         provider: pypi

--- a/travis_stages/deploy_pypi.yml
+++ b/travis_stages/deploy_pypi.yml
@@ -4,8 +4,13 @@ jobs:
       # This stage runs when a version-labelled tag is made. It deploys the
       # package to PyPI.
       if: tag =~ ^v[0-9]+\.
+      before_install: skip
       install: skip
+      before_script: skip
+      before_cache: skip
       script: skip
+      after_success: skip
+      # before_deploy is allowed
       deploy:
         provider: pypi
         distributions: sdist bdist_wheel
@@ -14,3 +19,4 @@ jobs:
         on:
             tags: true
         password: $TWINE_PASSWORD
+      after_script: skip

--- a/travis_stages/deploy_testpypi.yml
+++ b/travis_stages/deploy_testpypi.yml
@@ -4,6 +4,7 @@ jobs:
       # This stage runs when you make a PR to stable. It tests that the
       # deployment to testpypi works.
       if: "(branch = stable) and (type = pull_request)"
+      before_install: skip
       install:
         - pip install twine
         - pip install autorelease
@@ -11,9 +12,16 @@ jobs:
         # the branch tag to whatever is needed)
         #- pip install git+https://github.com/dwhswenson/autorelease.git@release-0.0.18#egg=autorelease
         - hash -r
+      before_script:
+        - if [ -z "$TWINE_USERNAME" ]; then echo "Missing TWINE_USERNAME"; fi
+        - if [ -z "$TWINE_PASSWORD" ]; then echo "Missing TWINE_PASSWORD"; fi
       script: 
         - bump-dev-version  # comes from autorelease
         - python setup.py --version
         - python setup.py sdist bdist_wheel
         - twine check dist/*
         - twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+      after_success: skip
+      after_failure: skip
+      # deploy stuff won't be run on PR; don't need to override
+      after_script: skip

--- a/travis_stages/deploy_testpypi.yml
+++ b/travis_stages/deploy_testpypi.yml
@@ -7,7 +7,8 @@ jobs:
       before_install: skip
       install:
         - pip install twine
-        - pip install autorelease
+        #- pip install autorelease
+        - pip install git+https://github.com/dwhswenson/autorelease@ops_fixes
         # this is for debugging anything in autorelease used here (change
         # the branch tag to whatever is needed)
         #- pip install git+https://github.com/dwhswenson/autorelease.git@release-0.0.18#egg=autorelease

--- a/travis_stages/deploy_testpypi.yml
+++ b/travis_stages/deploy_testpypi.yml
@@ -13,8 +13,8 @@ jobs:
         #- pip install git+https://github.com/dwhswenson/autorelease.git@release-0.0.18#egg=autorelease
         - hash -r
       before_script:
-        - if [ -z "$TWINE_USERNAME" ]; then echo "Missing TWINE_USERNAME"; fi
-        - if [ -z "$TWINE_PASSWORD" ]; then echo "Missing TWINE_PASSWORD"; fi
+        - if [ -z "$TWINE_USERNAME" ] ; then echo "Missing TWINE_USERNAME"; fi
+        - if [ -z "$TWINE_PASSWORD" ] ; then echo "Missing TWINE_PASSWORD"; fi
       script: 
         - bump-dev-version  # comes from autorelease
         - python setup.py --version

--- a/travis_stages/test_testpypi.yml
+++ b/travis_stages/test_testpypi.yml
@@ -5,6 +5,7 @@ jobs:
       # been deployed to testpypi. It checks that the deployed package
       # works.
       if: "(branch = stable) and (type = pull_request)"
+      before_install: skip
       install:
         - pip install autorelease
         # this is for debugging anything in autorelease used here (change
@@ -16,6 +17,7 @@ jobs:
         - export VERSION=`pypi-max-version $PROJECT`
         - echo "Installing ${PROJECT}==${VERSION} (allowing pre-releases)"
         - pip install --pre --force-reinstall --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple ${PROJECT}==${VERSION}
+      before_script: skip
       script: |
           if [ -n "$AUTORELEASE_TEST_TESTPYPI" ]; then
             eval $AUTORELEASE_TEST_TESTPYPI
@@ -24,3 +26,6 @@ jobs:
             python -c "import $PROJECT"
             py.test --pyargs $PROJECT
           fi
+      after_failure: skip
+      after_success: skip
+      after_script: skip

--- a/travis_stages/test_testpypi.yml
+++ b/travis_stages/test_testpypi.yml
@@ -7,7 +7,8 @@ jobs:
       if: "(branch = stable) and (type = pull_request)"
       before_install: skip
       install:
-        - pip install autorelease
+        #- pip install autorelease
+        - pip install git+https://github.com/dwhswenson/autorelease@ops_fixes
         # this is for debugging anything in autorelease used here (change
         # the branch tag to whatever is needed)
         #- pip install git+https://github.com/dwhswenson/autorelease.git@release-0.0.18#egg=autorelease


### PR DESCRIPTION
While getting Autorelease to work on OPS, I came across problems that hadn't existing in my simpler repositories.

* `bump_dev_version`: return v0.0.0.dev0 if URL 404s (first upload!)
* stages: deploy stages (at least) should override all job lifecycle phases