### PR TITLE
Support for PACKAGE_IMPORT_NAME

### DIFF
--- a/autorelease-travis.yml
+++ b/autorelease-travis.yml
@@ -2,7 +2,7 @@
 # for nonrelease, use @master
 # for release, use v${VERSION}, e.g., v1.0.0
 import:
-    - dwhswenson/autorelease:travis_stages/deploy_testpypi.yml@master
-    - dwhswenson/autorelease:travis_stages/cut_release.yml@master
-    - dwhswenson/autorelease:travis_stages/deploy_pypi.yml@master
-    - dwhswenson/autorelease:travis_stages/test_testpypi.yml@master
+    - dwhswenson/autorelease:travis_stages/deploy_testpypi.yml@package_import_name
+    - dwhswenson/autorelease:travis_stages/cut_release.yml@package_import_name
+    - dwhswenson/autorelease:travis_stages/deploy_pypi.yml@package_import_name
+    - dwhswenson/autorelease:travis_stages/test_testpypi.yml@package_import_name

--- a/autorelease-travis.yml
+++ b/autorelease-travis.yml
@@ -2,7 +2,7 @@
 # for nonrelease, use @master
 # for release, use v${VERSION}, e.g., v1.0.0
 import:
-    - dwhswenson/autorelease:travis_stages/deploy_testpypi.yml@package_import_name
-    - dwhswenson/autorelease:travis_stages/cut_release.yml@package_import_name
-    - dwhswenson/autorelease:travis_stages/deploy_pypi.yml@package_import_name
-    - dwhswenson/autorelease:travis_stages/test_testpypi.yml@package_import_name
+    - dwhswenson/autorelease:travis_stages/deploy_testpypi.yml@master
+    - dwhswenson/autorelease:travis_stages/cut_release.yml@master
+    - dwhswenson/autorelease:travis_stages/deploy_pypi.yml@master
+    - dwhswenson/autorelease:travis_stages/test_testpypi.yml@master

--- a/travis_stages/deploy_pypi.yml
+++ b/travis_stages/deploy_pypi.yml
@@ -15,7 +15,7 @@ jobs:
         provider: pypi
         distributions: sdist bdist_wheel
         #skip_cleanup: true  # need the readme.rst from the script stage
-        user: $TWINE_USERNAME
+        username: $TWINE_USERNAME
         on:
             tags: true
         password: $TWINE_PASSWORD

--- a/travis_stages/test_testpypi.yml
+++ b/travis_stages/test_testpypi.yml
@@ -23,10 +23,12 @@ jobs:
           if [ -n "$AUTORELEASE_TEST_TESTPYPI" ]; then
             eval $AUTORELEASE_TEST_TESTPYPI
           else
+            cd ~
+            echo "PACKAGE_IMPORT_NAME: $PACKAGE_IMPORT_NAME"
+            echo "PROJECT: $PROJECT"
             if [ -z "$PACKAGE_IMPORT_NAME" ]; then
               PACKAGE_IMPORT_NAME=$PROJECT
             fi
-            cd ~
             python -c "import $PACKAGE_IMPORT_NAME"
             py.test --pyargs $PACKAGE_IMPORT_NAME
           fi

--- a/travis_stages/test_testpypi.yml
+++ b/travis_stages/test_testpypi.yml
@@ -19,11 +19,12 @@ jobs:
         - echo "Installing ${PROJECT}==${VERSION} (allowing pre-releases)"
         - pip install --pre --force-reinstall --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple ${PROJECT}==${VERSION}
       before_script: |
-          if [-z "$PACKAGE_IMPORT_NAME" ]; then
+          if [ -z "$PACKAGE_IMPORT_NAME" ]; then
             export PACKAGE_IMPORT_NAME=$PROJECT
           fi
           echo "PROJECT: $PROJECT"
           echo "PACKAGE_IMPORT_NAME: $PACKAGE_IMPORT_NAME"
+          echo "AUTORELEASE_TEST_TESTPYPI: $AUTORELEASE_TEST_TESTPYPI"
       script: |
           if [ -n "$AUTORELEASE_TEST_TESTPYPI" ]; then
             eval $AUTORELEASE_TEST_TESTPYPI

--- a/travis_stages/test_testpypi.yml
+++ b/travis_stages/test_testpypi.yml
@@ -23,9 +23,12 @@ jobs:
           if [ -n "$AUTORELEASE_TEST_TESTPYPI" ]; then
             eval $AUTORELEASE_TEST_TESTPYPI
           else
+            if [ -z "$PACKAGE_IMPORT_NAME" ]; then
+              PACKAGE_IMPORT_NAME=$PROJECT
+            fi
             cd ~
-            python -c "import $PROJECT"
-            py.test --pyargs $PROJECT
+            python -c "import $PACKAGE_IMPORT_NAME"
+            py.test --pyargs $PACKAGE_IMPORT_NAME
           fi
       after_failure: skip
       after_success: skip

--- a/travis_stages/test_testpypi.yml
+++ b/travis_stages/test_testpypi.yml
@@ -26,9 +26,9 @@ jobs:
             cd ~
             echo "PACKAGE_IMPORT_NAME: $PACKAGE_IMPORT_NAME"
             echo "PROJECT: $PROJECT"
-            if [ -z "$PACKAGE_IMPORT_NAME" ]; then
-              PACKAGE_IMPORT_NAME=$PROJECT
-            fi
+            #if [ -z "$PACKAGE_IMPORT_NAME" ]; then
+              #PACKAGE_IMPORT_NAME=$PROJECT
+            #fi
             python -c "import $PACKAGE_IMPORT_NAME"
             py.test --pyargs $PACKAGE_IMPORT_NAME
           fi

--- a/travis_stages/test_testpypi.yml
+++ b/travis_stages/test_testpypi.yml
@@ -18,17 +18,17 @@ jobs:
         - export VERSION=`pypi-max-version $PROJECT`
         - echo "Installing ${PROJECT}==${VERSION} (allowing pre-releases)"
         - pip install --pre --force-reinstall --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple ${PROJECT}==${VERSION}
-      before_script: skip
+      before_script: |
+          if [-z "$PACKAGE_IMPORT_NAME" ]; then
+            export PACKAGE_IMPORT_NAME=$PROJECT
+          fi
+          echo "PROJECT: $PROJECT"
+          echo "PACKAGE_IMPORT_NAME: $PACKAGE_IMPORT_NAME"
       script: |
           if [ -n "$AUTORELEASE_TEST_TESTPYPI" ]; then
             eval $AUTORELEASE_TEST_TESTPYPI
           else
             cd ~
-            echo "PACKAGE_IMPORT_NAME: $PACKAGE_IMPORT_NAME"
-            echo "PROJECT: $PROJECT"
-            #if [ -z "$PACKAGE_IMPORT_NAME" ]; then
-              #PACKAGE_IMPORT_NAME=$PROJECT
-            #fi
             python -c "import $PACKAGE_IMPORT_NAME"
             py.test --pyargs $PACKAGE_IMPORT_NAME
           fi


### PR DESCRIPTION
This allows a user to specify the package import name as an environment variable, this overriding the project name from setuptools. The setuptools project name is the name used on PyPI; it is not always the same as the import name. This will otherwise use the default test script (import, then run `py.test --pyargs`.