### PR TITLE
Include explicit stage ordering for Travis

### DIFF
--- a/autorelease-local.yml
+++ b/autorelease-local.yml
@@ -1,5 +1,12 @@
+stages:
+  - test
+  - deploy_testpypi
+  - test_testpypi
+  - cut_release
+  - deploy_pypi
+
 import:
   - travis_stages/deploy_testpypi.yml
+  - travis_stages/test_testpypi.yml
   - travis_stages/cut_release.yml
   - travis_stages/deploy_pypi.yml
-  - travis_stages/test_testpypi.yml

--- a/autorelease-travis.yml
+++ b/autorelease-travis.yml
@@ -1,15 +1,16 @@
 # AUTORELEASE v0.2.1.dev0
 # for nonrelease, use @master
 # for release, use v${VERSION}, e.g., v1.0.0
-import:
-    - dwhswenson/autorelease:travis_stages/deploy_testpypi.yml@master
-    - dwhswenson/autorelease:travis_stages/cut_release.yml@master
-    - dwhswenson/autorelease:travis_stages/deploy_pypi.yml@master
-    - dwhswenson/autorelease:travis_stages/test_testpypi.yml@master
-
 stages:
     - test
     - deploy_testpypi
     - test_testpypi
     - deploy_pypi
     - cut_release
+
+import:
+    - dwhswenson/autorelease:travis_stages/deploy_testpypi.yml@master
+    - dwhswenson/autorelease:travis_stages/cut_release.yml@master
+    - dwhswenson/autorelease:travis_stages/deploy_pypi.yml@master
+    - dwhswenson/autorelease:travis_stages/test_testpypi.yml@master
+

--- a/autorelease-travis.yml
+++ b/autorelease-travis.yml
@@ -6,3 +6,10 @@ import:
     - dwhswenson/autorelease:travis_stages/cut_release.yml@master
     - dwhswenson/autorelease:travis_stages/deploy_pypi.yml@master
     - dwhswenson/autorelease:travis_stages/test_testpypi.yml@master
+
+stages:
+    - test
+    - deploy_testpypi
+    - test_testpypi
+    - deploy_pypi
+    - cut_release

--- a/autorelease-travis.yml
+++ b/autorelease-travis.yml
@@ -9,8 +9,8 @@ stages:
     - deploy_pypi
 
 import:
-    - dwhswenson/autorelease:travis_stages/deploy_pypi.yml@master
-    - dwhswenson/autorelease:travis_stages/cut_release.yml@master
-    - dwhswenson/autorelease:travis_stages/test_testpypi.yml@master
     - dwhswenson/autorelease:travis_stages/deploy_testpypi.yml@master
+    - dwhswenson/autorelease:travis_stages/test_testpypi.yml@master
+    - dwhswenson/autorelease:travis_stages/cut_release.yml@master
+    - dwhswenson/autorelease:travis_stages/deploy_pypi.yml@master
 

--- a/autorelease-travis.yml
+++ b/autorelease-travis.yml
@@ -5,12 +5,12 @@ stages:
     - test
     - deploy_testpypi
     - test_testpypi
-    - deploy_pypi
     - cut_release
+    - deploy_pypi
 
 import:
-    - dwhswenson/autorelease:travis_stages/deploy_testpypi.yml@master
-    - dwhswenson/autorelease:travis_stages/cut_release.yml@master
     - dwhswenson/autorelease:travis_stages/deploy_pypi.yml@master
+    - dwhswenson/autorelease:travis_stages/cut_release.yml@master
     - dwhswenson/autorelease:travis_stages/test_testpypi.yml@master
+    - dwhswenson/autorelease:travis_stages/deploy_testpypi.yml@master
 


### PR DESCRIPTION
Stages `deploy_testpypi` and `test_testpypi` must be done in the correct order. This attempts to ensure that.

There was some strangeness where this wasn't working (see https://github.com/dwhswenson/contact_map/pull/76 and https://travis-ci.community/t/9290 for more). However, it seems like (maybe?) it works now.