### PR TITLE
Start to CLI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -47,7 +47,7 @@ jobs:
           EVENT: ${{ github.event_name }}
           #EVENT_INFO: ${{ toJson(github.event) }}  # useful debug
         run: |
-          if [ "$EVENT" = "push" ]; then
+          if [ "$EVENT" != "pull_request" ]; then
             BRANCH=$REF
           else
             BRANCH=$PR_BRANCH

--- a/autorelease/check_runners.py
+++ b/autorelease/check_runners.py
@@ -83,6 +83,17 @@ class DefaultCheckRunner(CheckRunner):
             )
         ]
 
+    @staticmethod
+    def _get_branch_name(branch_name):
+        if branch_name.startswith('refs/heads/'):
+            branch = branch_name[11:]
+        elif branch_name.startswith('refs/tags/'):
+            branch = branch_name[10:]
+        else:
+            branch = branch_name
+
+        return branch
+
     def select_tests_from_sysargs(self):
         # TODO: this can be cleaned up by separating reusable parts
         parser = argparse.ArgumentParser()
@@ -91,17 +102,13 @@ class DefaultCheckRunner(CheckRunner):
         parser.add_argument('--allow-patch-skip', action='store_true',
                             default=False)
         opts = parser.parse_args()
-        if opts.branch.startswith('refs/heads/'):
-            branch = opts.branch[11:]
-        elif opts.branch.startswith('refs/tags/'):
-            branch = opts.branch[10:]
-        else:
-            branch = opts.branch
 
+        branch = self._get_branch_name(opts.branch)
         if branch in self.release_branches:
             print("TESTING AS RELEASE")
             allow_equal = (opts.event == 'cron'
-                           or opts.branch == self.tag_branch)
+                           or opts.event == 'schedule'
+                           or branch == self.tag_branch)
             tests = (self.tests
                      + self._reasonable_desired_version_test(
                          allow_equal=allow_equal,

--- a/autorelease/check_runners.py
+++ b/autorelease/check_runners.py
@@ -93,6 +93,8 @@ class DefaultCheckRunner(CheckRunner):
         opts = parser.parse_args()
         if opts.branch.startswith('refs/heads/'):
             branch = opts.branch[11:]
+        elif opts.branch.startswith('refs/tags/'):
+            branch = opts.branch[10:]
         else:
             branch = opts.branch
 

--- a/autorelease/gh_actions_stages/autorelease-default-env.sh
+++ b/autorelease/gh_actions_stages/autorelease-default-env.sh
@@ -1,0 +1,4 @@
+INSTALL_AUTORELEASE="python -m pip install autorelease==0.2.3"
+DIR=`dirname $0`
+source autorelease-env.sh
+

--- a/autorelease/gh_actions_stages/autorelease-default-env.sh
+++ b/autorelease/gh_actions_stages/autorelease-default-env.sh
@@ -1,4 +1,5 @@
 INSTALL_AUTORELEASE="python -m pip install autorelease==0.2.3"
-DIR=`dirname $0`
-source autorelease-env.sh
+if [ -f autorelease-env.sh ]; then
+    source autorelease-env.sh
+fi
 

--- a/autorelease/gh_actions_stages/autorelease-deploy.yml
+++ b/autorelease/gh_actions_stages/autorelease-deploy.yml
@@ -1,0 +1,31 @@
+name: Autorelease
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy_pypi:
+    runs-on: ubuntu-latest
+    name: "Deploy to PyPI"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - run: |  # TODO: move this to an action
+          source ./.github/workflows/autorelease-default-env.sh
+          cat autorelease-env.sh >> $GITHUB_ENV
+          eval $INSTALL_AUTORELEASE
+        name: "Install autorelease"
+      - run: |
+          python -m pip install twine wheel
+        name: "Install release tools"
+      - run: |
+          python setup.py sdist bdist_wheel
+          twine check dist/*
+        name: "Build and check package"
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.pypi_password }}
+        name: "Deploy to testpypi"
+ 

--- a/autorelease/gh_actions_stages/autorelease-gh-rel.yml
+++ b/autorelease/gh_actions_stages/autorelease-gh-rel.yml
@@ -1,0 +1,27 @@
+name: Autorelease
+on:
+  push:
+    branches:
+      - stable
+
+jobs:
+  release-gh:
+    runs-on: ubuntu-latest
+    name: "Cut release"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+      - run: |  # TODO: move this to an action
+          source ./.github/workflows/autorelease-default-env.sh
+          cat autorelease-env.sh >> $GITHUB_ENV
+          eval $INSTALL_AUTORELEASE
+        name: "Install autorelease"
+      - run: |
+          VERSION=`python setup.py --version`
+          PROJECT=`python setup.py --name`
+          echo $PROJECT $VERSION
+          autorelease-release --project $PROJECT --version $VERSION --token $AUTORELEASE_TOKEN
+        env:
+          AUTORELEASE_TOKEN: ${{ secrets.AUTORELEASE_TOKEN }}

--- a/autorelease/gh_actions_stages/autorelease-prep.yml
+++ b/autorelease/gh_actions_stages/autorelease-prep.yml
@@ -1,0 +1,56 @@
+name: "Autorelease"
+on:
+  pull_request:
+    branches:
+      - stable
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy_testpypi:
+    runs-on: ubuntu-latest
+    name: "Deployment test"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - run: |  # TODO: move this to an action
+          source ./.github/workflows/autorelease-default-env.sh
+          cat autorelease-env.sh >> $GITHUB_ENV
+          eval $INSTALL_AUTORELEASE
+        name: "Install autorelease"
+      - run: |
+          python -m pip install twine wheel
+        name: "Install release tools"
+      - run: |
+          bump-dev-version
+          python setup.py --version
+        name: "Bump testpypi dev version"
+      - run: |
+          python setup.py sdist bdist_wheel
+          twine check dist/*
+        name: "Build and check package"
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.testpypi_password }}
+          repository_url: https://test.pypi.org/legacy/
+        name: "Deploy to testpypi"
+  test_testpypi:
+    runs-on: ubuntu-latest
+    name: "Test deployed"
+    needs: deploy_testpypi
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - run: |  # TODO: move this to an action
+          source ./.github/workflows/autorelease-default-env.sh
+          cat autorelease-env.sh >> $GITHUB_ENV
+          eval $INSTALL_AUTORELEASE
+        name: "Install autorelease"
+      - run: test-testpypi
+

--- a/autorelease/scripts/cli.py
+++ b/autorelease/scripts/cli.py
@@ -1,0 +1,22 @@
+import click
+
+from autorelease.scripts.vendor import vendor_actions
+
+@click.group()
+def cli():
+    pass
+
+
+@click.group()
+def vendor():
+    pass
+
+@vendor.command()
+def actions():
+    print("vendoring actions")
+    vendor_actions(base_path='.')
+
+cli.add_command(vendor)
+
+if __name__ == "__main__":
+    cli()

--- a/autorelease/scripts/vendor.py
+++ b/autorelease/scripts/vendor.py
@@ -1,0 +1,23 @@
+import pkg_resources
+import pathlib
+import shutil
+
+import click
+
+def vendor(resources, base_path, relative_target_dir):
+    for resource in resources:
+        orig_loc = pkg_resources.resource_filename('autorelease', resource)
+        name = pathlib.Path(orig_loc).name
+        target_dir = base_path / relative_target_dir
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target_loc = base_path / relative_target_dir / name
+        # print(f"cp {orig_loc} {target_loc}")
+        shutil.copy(orig_loc, target_loc)
+
+def vendor_actions(base_path):
+    resources = ['autorelease-default-env.sh', 'autorelease-prep.yml',
+                 'autorelease-gh-rel.yml', 'autorelease-deploy.yml']
+    resources = ['gh_actions_stages/' + res for res in resources]
+    target_dir = pathlib.Path('.github/workflows')
+    vendor(resources, base_path, target_dir)
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,10 +35,15 @@ install_requires =
     future
     requests
     python-dateutil
+    click
 packages = find:
 scripts =
     script_stages/deploy-pypi
     script_stages/test-testpypi
+
+[options.package_data]
+autorelease =
+    - ../gh_actions_stages/*
 
 [options.entry_points]
 console_scripts = 
@@ -47,6 +52,7 @@ console_scripts =
     bump-dev-version = autorelease.scripts.bump_dev_version:main
     pypi-max-version = autorelease.scripts.bump_dev_version:get_max
     wait-for-testpypi = autorelease.scripts.bump_dev_version:wait_for_max
+    autorelease = autorelease.scripts.cli:cli
 
 [bdist_wheel]
 universal=1


### PR DESCRIPTION
This is the first step toward a CLI that will unify various scripts as subcommands.

For now, it just adds one subcommand (indeed, just one sub-subcommand):

```
autorelease vendor actions
```

This will add Autorelease GitHub Actions support to the repository (currently, must run from root level of the repo). After this, the user will need to add the files to version control with something like `git add .github/workflows/*`, but the 4 files associated with the autorelease process will be there.