### PR TITLE
Release 0.2.5

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,7 +1,7 @@
 package:
   name: autorelease
   # add ".dev0" for unreleased versions
-  version: "0.2.4"
+  version: "0.2.5"
 
 source:
   path: ../../

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = autorelease
-version = 0.2.4
+version = 0.2.5
 # version should end in .dev0 if this isn't to be released
 short_description = Tools to keep the release process clean.
 description = Tools to keep the release process clean.


### PR DESCRIPTION
For 0.2.2 <= version <= 0.3, we are testing/implementing support for other CI platforms in Autorelease.