### PR TITLE
Add hook for before-install in install-testpypi

### DIFF
--- a/script_stages/install-testpypi
+++ b/script_stages/install-testpypi
@@ -8,6 +8,9 @@ export PROJECT=`python setup.py --name`
 export VERSION=`pypi-max-version $PROJECT`
 echo "Installing ${PROJECT}==${VERSION} (allowing pre-releases)"
 if [ -z "$DRY" ]; then
+    if [ -f "./.autorelease/before-install" ];
+        source ./.autorelease/before-install || exit 1
+    fi
     python -m pip install --pre --force-reinstall \
         --index-url https://test.pypi.org/simple/ \
         --extra-index-url https://pypi.org/simple ${PROJECT}==${VERSION}


### PR DESCRIPTION
This allows, for example, the possibility of downloading additional dependencies from a non-PyPI source (for example, to install from a specific branch of the repo).