### PR TITLE
Vendored actions are now templates

### DIFF
--- a/.github/workflows/autorelease-default-env.sh
+++ b/.github/workflows/autorelease-default-env.sh
@@ -1,4 +1,6 @@
-INSTALL_AUTORELEASE="python -m pip install autorelease==0.3.0"
+# Vendored from Autorelease 0.3.1
+# Update by updating Autorelease and running `autorelease vendor actions`
+INSTALL_AUTORELEASE="python -m pip install autorelease==0.3.1"
 if [ -f autorelease-env.sh ]; then
     source autorelease-env.sh
 fi

--- a/.github/workflows/autorelease-deploy.yml
+++ b/.github/workflows/autorelease-deploy.yml
@@ -1,6 +1,6 @@
 # Vendored from Autorelease 0.3.1
 # Update by updating Autorelease and running `autorelease vendor actions`
-name: Autorelease
+name: "Autorelease Deploy"
 on:
   release:
     types: [published]

--- a/.github/workflows/autorelease-deploy.yml
+++ b/.github/workflows/autorelease-deploy.yml
@@ -1,3 +1,5 @@
+# Vendored from Autorelease 0.3.1
+# Update by updating Autorelease and running `autorelease vendor actions`
 name: Autorelease
 on:
   release:

--- a/.github/workflows/autorelease-gh-rel.yml
+++ b/.github/workflows/autorelease-gh-rel.yml
@@ -1,9 +1,10 @@
 # Vendored from Autorelease 0.3.1
 # Update by updating Autorelease and running `autorelease vendor actions`
-name: Autorelease
+name: "Autorelease Release"
 on:
   push:
     branches:
+      # TODO: this should come from yaml conf
       - stable
 
 jobs:
@@ -33,3 +34,4 @@ jobs:
           autorelease-release --project $PROJECT --version $VERSION --token $AUTORELEASE_TOKEN
         env:
           AUTORELEASE_TOKEN: ${{ secrets.AUTORELEASE_TOKEN }}
+        name: "Cut release"

--- a/.github/workflows/autorelease-gh-rel.yml
+++ b/.github/workflows/autorelease-gh-rel.yml
@@ -1,3 +1,5 @@
+# Vendored from Autorelease 0.3.1
+# Update by updating Autorelease and running `autorelease vendor actions`
 name: Autorelease
 on:
   push:

--- a/.github/workflows/autorelease-prep.yml
+++ b/.github/workflows/autorelease-prep.yml
@@ -1,9 +1,10 @@
 # Vendored from Autorelease 0.3.1
 # Update by updating Autorelease and running `autorelease vendor actions`
-name: "Autorelease"
+name: "Autorelease testpypi"
 on:
   pull_request:
     branches:
+      # TODO: this should come from yaml conf
       - stable
 
 defaults:

--- a/.github/workflows/autorelease-prep.yml
+++ b/.github/workflows/autorelease-prep.yml
@@ -1,5 +1,5 @@
-# File vencdored from Autorelease; specific version information should be in
-# the INSTALL_AUTORELEASE variable in autorelease-default-env.sh
+# Vendored from Autorelease 0.3.1
+# Update by updating Autorelease and running `autorelease vendor actions`
 name: "Autorelease"
 on:
   pull_request:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,11 +2,11 @@ name: "Unit tests"
 on:
   pull_request:
     branches:
-      - master
+      - main
       - stable
   push:
     branches:
-      - master
+      - main
     tags:
       - "v*"
   schedule:

--- a/autorelease/gh_actions_stages/autorelease-default-env.sh
+++ b/autorelease/gh_actions_stages/autorelease-default-env.sh
@@ -1,4 +1,6 @@
-INSTALL_AUTORELEASE="python -m pip install autorelease==0.3.0"
+# Vendored from Autorelease $VERSION
+# Update by updating Autorelease and running `autorelease vendor actions`
+INSTALL_AUTORELEASE="python -m pip install autorelease==$VERSION"
 if [ -f autorelease-env.sh ]; then
     source autorelease-env.sh
 fi

--- a/autorelease/gh_actions_stages/autorelease-deploy.yml
+++ b/autorelease/gh_actions_stages/autorelease-deploy.yml
@@ -1,6 +1,6 @@
 # Vendored from Autorelease $VERSION
 # Update by updating Autorelease and running `autorelease vendor actions`
-name: Autorelease
+name: "Autorelease Deploy"
 on:
   release:
     types: [published]

--- a/autorelease/gh_actions_stages/autorelease-deploy.yml
+++ b/autorelease/gh_actions_stages/autorelease-deploy.yml
@@ -1,3 +1,5 @@
+# Vendored from Autorelease $VERSION
+# Update by updating Autorelease and running `autorelease vendor actions`
 name: Autorelease
 on:
   release:
@@ -15,12 +17,12 @@ jobs:
       - run: |  # TODO: move this to an action
           source ./.github/workflows/autorelease-default-env.sh
           if [ -f "autorelease-env.sh" ]; then
-            cat autorelease-env.sh >> $GITHUB_ENV
+            cat autorelease-env.sh >> $$GITHUB_ENV
           fi
           if [ -f "./.autorelease/install-autorelease" ]; then
             source ./.autorelease/install-autorelease
           else
-            eval $INSTALL_AUTORELEASE
+            eval $$INSTALL_AUTORELEASE
           fi
         name: "Install autorelease"
       - run: |
@@ -32,6 +34,6 @@ jobs:
         name: "Build and check package"
       - uses: pypa/gh-action-pypi-publish@master
         with:
-          password: ${{ secrets.pypi_password }}
+          password: $${{ secrets.pypi_password }}
         name: "Deploy to pypi"
  

--- a/autorelease/gh_actions_stages/autorelease-gh-rel.yml
+++ b/autorelease/gh_actions_stages/autorelease-gh-rel.yml
@@ -1,3 +1,5 @@
+# Vendored from Autorelease $VERSION
+# Update by updating Autorelease and running `autorelease vendor actions`
 name: Autorelease
 on:
   push:
@@ -16,18 +18,18 @@ jobs:
       - run: |  # TODO: move this to an action
           source ./.github/workflows/autorelease-default-env.sh
           if [ -f "autorelease-env.sh" ]; then
-            cat autorelease-env.sh >> $GITHUB_ENV
+            cat autorelease-env.sh >> $$GITHUB_ENV
           fi
           if [ -f "./.autorelease/install-autorelease" ]; then
             source ./.autorelease/install-autorelease
           else
-            eval $INSTALL_AUTORELEASE
+            eval $$INSTALL_AUTORELEASE
           fi
         name: "Install autorelease"
       - run: |
           VERSION=`python setup.py --version`
           PROJECT=`python setup.py --name`
-          echo $PROJECT $VERSION
-          autorelease-release --project $PROJECT --version $VERSION --token $AUTORELEASE_TOKEN
+          echo $$PROJECT $$VERSION
+          autorelease-release --project $$PROJECT --version $$VERSION --token $$AUTORELEASE_TOKEN
         env:
-          AUTORELEASE_TOKEN: ${{ secrets.AUTORELEASE_TOKEN }}
+          AUTORELEASE_TOKEN: $${{ secrets.AUTORELEASE_TOKEN }}

--- a/autorelease/gh_actions_stages/autorelease-gh-rel.yml
+++ b/autorelease/gh_actions_stages/autorelease-gh-rel.yml
@@ -1,9 +1,10 @@
 # Vendored from Autorelease $VERSION
 # Update by updating Autorelease and running `autorelease vendor actions`
-name: Autorelease
+name: "Autorelease Release"
 on:
   push:
     branches:
+      # TODO: this should come from yaml conf
       - stable
 
 jobs:
@@ -33,3 +34,4 @@ jobs:
           autorelease-release --project $$PROJECT --version $$VERSION --token $$AUTORELEASE_TOKEN
         env:
           AUTORELEASE_TOKEN: $${{ secrets.AUTORELEASE_TOKEN }}
+        name: "Cut release"

--- a/autorelease/gh_actions_stages/autorelease-prep.yml
+++ b/autorelease/gh_actions_stages/autorelease-prep.yml
@@ -1,9 +1,10 @@
 # Vendored from Autorelease $VERSION
 # Update by updating Autorelease and running `autorelease vendor actions`
-name: "Autorelease"
+name: "Autorelease testpypi"
 on:
   pull_request:
     branches:
+      # TODO: this should come from yaml conf
       - stable
 
 defaults:

--- a/autorelease/gh_actions_stages/autorelease-prep.yml
+++ b/autorelease/gh_actions_stages/autorelease-prep.yml
@@ -1,5 +1,5 @@
-# File vencdored from Autorelease; specific version information should be in
-# the INSTALL_AUTORELEASE variable in autorelease-default-env.sh
+# Vendored from Autorelease $VERSION
+# Update by updating Autorelease and running `autorelease vendor actions`
 name: "Autorelease"
 on:
   pull_request:
@@ -22,12 +22,12 @@ jobs:
       - run: |  # TODO: move this to an action
           source ./.github/workflows/autorelease-default-env.sh
           if [ -f "autorelease-env.sh" ]; then
-            cat autorelease-env.sh >> $GITHUB_ENV
+            cat autorelease-env.sh >> $$GITHUB_ENV
           fi
           if [ -f "./.autorelease/install-autorelease" ]; then
             source ./.autorelease/install-autorelease
           else
-            eval $INSTALL_AUTORELEASE
+            eval $$INSTALL_AUTORELEASE
           fi
         name: "Install autorelease"
       - run: |
@@ -43,7 +43,7 @@ jobs:
         name: "Build and check package"
       - uses: pypa/gh-action-pypi-publish@master
         with:
-          password: ${{ secrets.testpypi_password }}
+          password: $${{ secrets.testpypi_password }}
           repository_url: https://test.pypi.org/legacy/
         name: "Deploy to testpypi"
   test_testpypi:
@@ -58,12 +58,12 @@ jobs:
       - run: |  # TODO: move this to an action
           source ./.github/workflows/autorelease-default-env.sh
           if [ -f "autorelease-env.sh" ]; then
-            cat autorelease-env.sh >> $GITHUB_ENV
+            cat autorelease-env.sh >> $$GITHUB_ENV
           fi
           if [ -f "./.autorelease/install-autorelease" ]; then
             source ./.autorelease/install-autorelease
           else
-            eval $INSTALL_AUTORELEASE
+            eval $$INSTALL_AUTORELEASE
           fi
         name: "Install autorelease"
       - name: "Install testpypi version"
@@ -71,6 +71,6 @@ jobs:
       - name: "Test testpypi version"
         run: |
           if [ -f "autorelease-env.sh" ]; then
-            cat autorelease-env.sh >> $GITHUB_ENV
+            cat autorelease-env.sh >> $$GITHUB_ENV
           fi
           test-testpypi

--- a/autorelease/scripts/vendor.py
+++ b/autorelease/scripts/vendor.py
@@ -1,8 +1,8 @@
-import pkg_resources
+import string
 import pathlib
-import shutil
-
-import click
+import pkg_resources
+from packaging.version import Version
+import autorelease
 
 def vendor(resources, base_path, relative_target_dir):
     for resource in resources:
@@ -12,7 +12,12 @@ def vendor(resources, base_path, relative_target_dir):
         target_dir.mkdir(parents=True, exist_ok=True)
         target_loc = base_path / relative_target_dir / name
         # print(f"cp {orig_loc} {target_loc}")
-        shutil.copy(orig_loc, target_loc)
+        with open(orig_loc, mode='r') as rfile:
+            template = string.Template(rfile.read())
+
+        version = Version(autorelease.version.version).base_version
+        with open(target_loc, mode='w') as wfile:
+            wfile.write(template.substitute(VERSION=version))
 
 def vendor_actions(base_path):
     resources = ['autorelease-default-env.sh', 'autorelease-prep.yml',


### PR DESCRIPTION
This converts vendored workflows to templates. This allows us to attach a version to the user-visible workflow text while still keeping out version as a single source of truth. Also improves some naming of the workflows.