### PR TITLE
YAML config support in the click CLI; release notes in click CLI

### DIFF
--- a/autorelease/scripts/check.py
+++ b/autorelease/scripts/check.py
@@ -24,9 +24,9 @@ def checker_from_yaml_dict(release_check):
     return checker
 
 
-def run_checks(yml, branch=None, event=None, allow_patch_skip=False):
-    dct = yaml.load(yml, Loader=yaml.FullLoader)
+def run_checks(dct, branch=None, event=None, allow_patch_skip=False):
     release_check = dct['release-check']
+    release_check.update(dct['repo'])
     checker = checker_from_yaml_dict(release_check)
     if branch is None and event is None:
         branch, event = checker.get_branch_event_from_github_env()

--- a/autorelease/scripts/cli.py
+++ b/autorelease/scripts/cli.py
@@ -1,18 +1,83 @@
+import os
 import click
+import yaml
 
 from autorelease.scripts.vendor import vendor_actions
 from autorelease.scripts.check import run_checks
+from autorelease import ReleaseNoteWriter
+
+
+def _find_first_file(pathlist):
+    for p in pathlist:
+        if os.path.exists(p):
+            return p
+    return None
+
+def load_yaml(user_input, default_pathlist):
+    if user_input is not None:
+        dct = yaml.load(user_input, Loader=yaml.FullLoader)
+    else:
+        filename = _find_first_file(default_pathlist)
+        if filename is None:
+            raise RuntimeError("No config file could be found")
+        with open(filename, mode='r') as f:
+            dct = yaml.load(f, Loader=yaml.FullLoader)
+
+    return dct
+
+def load_config(user_input):
+    paths = [
+        ".autorelease.yml",
+        "autorelease.yml",
+        os.path.join(".autorelease", "autorelease.yml"),
+        os.path.join(".autorelease", "conf.yml"),
+    ]
+    return load_yaml(user_input, paths)
+
+def load_auth(user_input):
+    paths = [
+        os.path.join(os.path.expanduser("~"), ".autorelease-auth.yml"),
+        os.path.join(".autorelease", "auth.yml"),
+        os.path.join(".autorelease", "autorelease-auth.yml"),
+        ".autorelease-auth.yml",
+        "autorelease-auth.yml",
+    ]
+    return load_yaml(user_input, paths)
+
 
 @click.group()
 def cli():
     pass
 
 @cli.command()
-@click.option('--conf', type=click.File('r'), default='autorelease.yml')
+@click.option('--conf', type=click.File('r'))
 @click.option('--branch', default=None)
 @click.option('--event', default=None)
 def check(conf, branch, event):
-    run_checks(conf, branch, event)
+    dct = load_config(conf)
+    run_checks(dct, branch, event)
+
+@cli.command()
+@click.option('--conf', type=click.File('r'))
+def config(conf):
+    from pprint import pprint
+    config = load_config(conf)
+    pprint(config)
+
+
+@cli.command()
+@click.option('--conf', type=click.File('r'))
+@click.option('--auth', type=click.File('r'))
+@click.option('--since-release', type=str, default=None)
+@click.option('-o', '--output', type=str)
+def notes(conf, auth, since_release, output):
+    config = load_config(conf)
+    github_user = load_auth(auth)
+    notes_conf = config['notes']
+    notes_conf.update(github_user)
+    notes_conf['project'] = config['project']
+    writer = ReleaseNoteWriter(config=notes_conf)
+    writer.write_release_notes(outfile=output)
 
 @click.group()
 def vendor():

--- a/autorelease/scripts/release.py
+++ b/autorelease/scripts/release.py
@@ -82,7 +82,7 @@ def main():
         repo=repo,
         github_user=github_user
     )
-    
+
     # testing
     expected_pr = releaser.find_relevant_pr()
     print("Expected PR: " + str(expected_pr))


### PR DESCRIPTION
Add general yaml config support in the click-based CLI

Also:

* put write-release-notes in the CLI (as `autorelease notes`)
* updated the YAML format (this may change some more, but this is an improvement)

YAML updates:

* **Unify release notes with checks.** Now the top-level headings are `project`, `repo` (settings on release branches, tag names, and paths to repo and setup), `notes` (containing old YAML config for release notes, excluding project), and `release-check` (for details of what we check in the `autorelease check` method, e.g., where to find versions).
* **Separate authorization.** This can be in `.autorelease/auth.yaml`, or, better yet, in `~/.autorelease-auth.yml`.