### PR TITLE
Bump 0.4.0.dev0

### DIFF
--- a/autorelease-travis.yml
+++ b/autorelease-travis.yml
@@ -1,4 +1,4 @@
-# AUTORELEASE v0.3.2
+# AUTORELEASE v0.4.0.dev0
 # for nonrelease, use @main
 # for release, use v${VERSION}, e.g., v1.0.0
 stages:
@@ -9,7 +9,7 @@ stages:
     - deploy pypi
 
 import:
-    - dwhswenson/autorelease:travis_stages/deploy_testpypi.yml@v0.3.2
-    - dwhswenson/autorelease:travis_stages/test_testpypi.yml@v0.3.2
-    - dwhswenson/autorelease:travis_stages/cut_release.yml@v0.3.2
-    - dwhswenson/autorelease:travis_stages/deploy_pypi.yml@v0.3.2
+    - dwhswenson/autorelease:travis_stages/deploy_testpypi.yml@main
+    - dwhswenson/autorelease:travis_stages/test_testpypi.yml@main
+    - dwhswenson/autorelease:travis_stages/cut_release.yml@main
+    - dwhswenson/autorelease:travis_stages/deploy_pypi.yml@main

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,7 +1,7 @@
 package:
   name: autorelease
   # add ".dev0" for unreleased versions
-  version: "0.3.2"
+  version: "0.4.0.dev0"
 
 source:
   path: ../../

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = autorelease
-version = 0.3.2
+version = 0.4.0.dev0
 # version should end in .dev0 if this isn't to be released
 short_description = Tools to keep the release process clean.
 description = Tools to keep the release process clean.


### PR DESCRIPTION
Going straight to 0.4.0 because there's already enough stuff in the pipeline to guarantee that bump.