### PR TITLE
Use the `autorelease check` command locally

### DIFF
--- a/.autorelease/autorelease.yml
+++ b/.autorelease/autorelease.yml
@@ -1,0 +1,40 @@
+# project configuration
+project:
+  project_name: Autorelease
+  repo_owner: dwhswenson
+  repo_name: autorelease
+
+# repo configuration: how you organize releases and the repo
+repo:
+  # these are relative to where you run the script from
+  repo-path:  '.'
+  setup-path: '.'
+  release-branches:
+    - stable
+  release-tag: "v{BASE_VERSION}"
+
+# writing release notes
+notes:
+  labels:
+    - label: enhancement
+      heading: New features
+    - label: bugfix
+      heading: Bugs fixed
+    - label: misc PR
+      heading: Miscellaneous improvements
+
+  standard_contributors:
+    - dwhswenson
+
+# running release checks
+release-check:
+  versions:
+    - setup-cfg
+    - conda: devtools/conda-recipe/meta.yaml
+  skip: []
+
+
+# TODO: this replaces various environment variables
+env:
+  package-import-name: 'autorelease'
+  dry: ""

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -59,3 +59,4 @@ jobs:
           python -c "import autorelease"
           autorelease-release -h
           python release_check.py
+          autorelease check

--- a/autorelease/scripts/vendor.py
+++ b/autorelease/scripts/vendor.py
@@ -1,5 +1,8 @@
 import string
-import pathlib
+try:
+    import pathlib
+except ImportError:  # py2
+    import pathlib2
 import pkg_resources
 from packaging.version import Version
 import autorelease

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pyyaml
 gitpython
 requests
 future
+pathlib2


### PR DESCRIPTION
For now we'll also keep the `python release_check.py` command, but we should be dogfooding our `autorelease check` command prior to the 0.4 release.