### PR TITLE
Drop Python 2.7; add Python 3.11

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,11 +23,11 @@ jobs:
     strategy:
       matrix:
         CONDA_PY:
+          - "3.11"
           - "3.10"
           - "3.9"
           - "3.8"
           - "3.7"
-          - "2.7"
            
     steps:
       - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ classifiers =
     Topic :: Software Development :: Testing
 
 [options]
-python_requires = ">= 3.7"
+python_requires = >=3.7
 install_requires =
     packaging
     pyyaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ classifiers =
     Topic :: Software Development :: Testing
 
 [options]
+python_requires = ">= 3.7"
 install_requires =
     packaging
     pyyaml


### PR DESCRIPTION
This drops support for Python 2.7, as the containers used by `actions/setup-python` no longer include 2.7.

This means we no longer test in Python 2.7, although we're not (yet) actually breaking support for 2.7. Ideally, we should create an action to do the autorelease checks, so it can run in isolation from the user environment. The only place we might run on 2.7 is when doing those checks. Deployment and deployment tests should always be done from a Python 3 environment.