### PR TITLE
Updates to fix deprecations, modernize build

### DIFF
--- a/.github/workflows/autorelease-default-env.sh
+++ b/.github/workflows/autorelease-default-env.sh
@@ -1,6 +1,6 @@
-# Vendored from Autorelease 0.6.1
+# Vendored from Autorelease 0.6.2
 # Update by updating Autorelease and running `autorelease vendor actions`
-INSTALL_AUTORELEASE="python -m pip install autorelease==0.6.1"
+INSTALL_AUTORELEASE="python -m pip install autorelease==0.6.2"
 if [ -f autorelease-env.sh ]; then
     source autorelease-env.sh
 fi

--- a/.github/workflows/autorelease-deploy.yml
+++ b/.github/workflows/autorelease-deploy.yml
@@ -1,4 +1,4 @@
-# Vendored from Autorelease 0.6.1
+# Vendored from Autorelease 0.6.2
 # Update by updating Autorelease and running `autorelease vendor actions`
 name: "Autorelease Deploy"
 on:
@@ -13,26 +13,15 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - run: |  # TODO: move this to an action
-          source ./.github/workflows/autorelease-default-env.sh
-          if [ -f "autorelease-env.sh" ]; then
-            cat autorelease-env.sh >> $GITHUB_ENV
-          fi
-          if [ -f "./.autorelease/install-autorelease" ]; then
-            source ./.autorelease/install-autorelease
-          else
-            eval $INSTALL_AUTORELEASE
-          fi
-        name: "Install autorelease"
       - run: |
-          python -m pip install twine wheel
+          python -m pip install twine wheel build
         name: "Install release tools"
       - run: |
-          python setup.py sdist bdist_wheel
+          python -m build --sdist --wheel
           twine check dist/*
         name: "Build and check package"
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/autorelease-gh-rel.yml
+++ b/.github/workflows/autorelease-gh-rel.yml
@@ -1,4 +1,4 @@
-# Vendored from Autorelease 0.6.1
+# Vendored from Autorelease 0.6.2
 # Update by updating Autorelease and running `autorelease vendor actions`
 name: "Autorelease Release"
 on:

--- a/.github/workflows/autorelease-prep.yml
+++ b/.github/workflows/autorelease-prep.yml
@@ -1,4 +1,4 @@
-# Vendored from Autorelease 0.6.1
+# Vendored from Autorelease 0.6.2
 # Update by updating Autorelease and running `autorelease vendor actions`
 name: "Autorelease testpypi"
 on:

--- a/autorelease/gh_actions_stages/autorelease-deploy.yml
+++ b/autorelease/gh_actions_stages/autorelease-deploy.yml
@@ -13,26 +13,15 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - run: |  # TODO: move this to an action
-          source ./.github/workflows/autorelease-default-env.sh
-          if [ -f "autorelease-env.sh" ]; then
-            cat autorelease-env.sh >> $$GITHUB_ENV
-          fi
-          if [ -f "./.autorelease/install-autorelease" ]; then
-            source ./.autorelease/install-autorelease
-          else
-            eval $$INSTALL_AUTORELEASE
-          fi
-        name: "Install autorelease"
       - run: |
-          python -m pip install twine wheel
+          python -m pip install twine wheel build
         name: "Install release tools"
       - run: |
-          python setup.py sdist bdist_wheel
+          python -m build --sdist --wheel
           twine check dist/*
         name: "Build and check package"
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/autorelease/scripts/vendor.py
+++ b/autorelease/scripts/vendor.py
@@ -2,8 +2,11 @@ import string
 try:
     import pathlib
 except ImportError:  # py2
-    import pathlib2
-import pkg_resources
+    import pathlib2 as pathlib
+try:
+    from importlib import resources as importlib_resources
+except ImportError:  # py < 3.7
+    import importlib_resources
 from packaging.version import Version
 import autorelease
 
@@ -13,6 +16,8 @@ import re
 def extract_github_owner_and_repo(url):
     github_url_re = ".*github.com:(?P<owner>.*)/(?P<repo>.*)"
     m = re.match(github_url_re, url)
+    if m is None:
+        raise ValueError(f"Unable to parse GitHub URL: {url}")
     owner = m.group('owner')
     repo = m.group('repo')
     if repo.endswith('.git'):
@@ -70,17 +75,29 @@ def get_substitution_mapping(config=None):
 
 def vendor(resources, base_path, relative_target_dir, substitutions):
     for resource in resources:
-        orig_loc = pkg_resources.resource_filename('autorelease', resource)
-        name = pathlib.Path(orig_loc).name
+        # Use importlib.resources to get the resource content
+        try:
+            # For Python 3.9+
+            resource_files = importlib_resources.files('autorelease')
+            resource_path = resource_files / resource
+            with resource_path.open('r') as rfile:
+                template_content = rfile.read()
+        except AttributeError:
+            # For Python 3.7-3.8
+            with importlib_resources.path('autorelease', resource) as resource_path:
+                with open(resource_path, mode='r') as rfile:
+                    template_content = rfile.read()
+
+        name = pathlib.Path(resource).name
         target_dir = base_path / relative_target_dir
         target_dir.mkdir(parents=True, exist_ok=True)
         target_loc = base_path / relative_target_dir / name
-        # print(f"cp {orig_loc} {target_loc}")
-        with open(orig_loc, mode='r') as rfile:
-            template = string.Template(rfile.read())
+        # print(f"cp {resource} {target_loc}")
+        template = string.Template(template_content)
 
         with open(target_loc, mode='w') as wfile:
             wfile.write(template.substitute(**substitutions))
+
 
 def vendor_actions(base_path):
     resources = ['autorelease-default-env.sh', 'autorelease-prep.yml',
@@ -89,4 +106,3 @@ def vendor_actions(base_path):
     target_dir = pathlib.Path('.github/workflows')
     substitutions = get_substitution_mapping()
     vendor(resources, base_path, target_dir, substitutions)
-

--- a/autorelease/scripts/vendor.py
+++ b/autorelease/scripts/vendor.py
@@ -14,7 +14,7 @@ import git
 import re
 
 def extract_github_owner_and_repo(url):
-    github_url_re = ".*github.com:(?P<owner>.*)/(?P<repo>.*)"
+    github_url_re = r".*github.com:(?P<owner>.*)/(?P<repo>.*)"
     m = re.match(github_url_re, url)
     if m is None:
         raise ValueError(f"Unable to parse GitHub URL: {url}")


### PR DESCRIPTION
This has several small updates to address deprecated behavior and to modernize some aspects of building.

* Update autorelease-deploy script to use `python -m build` instead of `python setup.py`
* Update autorelease-deploy script to not install autorelease (no longer needed)
* Update vendor.py to use `importlib.resources` instead of `pkg_resources`
* Update vendor.py to use raw string for regex