### PR TITLE
Let user specify repo for `vendor actions`

### DIFF
--- a/.autorelease/test-testpypi
+++ b/.autorelease/test-testpypi
@@ -3,4 +3,4 @@
 echo "Using custom test-testpypi"
 cd ~
 python -c "import autorelease"
-autorelease vendor actions --dry
+autorelease vendor actions --repo "dwhswenson/autorelease" --dry

--- a/autorelease/scripts/cli.py
+++ b/autorelease/scripts/cli.py
@@ -115,10 +115,12 @@ def vendor():
     pass
 
 @vendor.command()
+@click.option('--repo', type=str, default=None,
+              help="GitHub repo in the form owner/repo")
 @click.option('--dry', is_flag=True, default=False)
-def actions(dry):
+def actions(repo, dry):
     print("vendoring actions")
-    vendor_actions(base_path='.', dry=dry)
+    vendor_actions(base_path='.', owner_repo=repo, dry=dry)
 
 cli.add_command(vendor)
 

--- a/autorelease/scripts/vendor.py
+++ b/autorelease/scripts/vendor.py
@@ -57,8 +57,9 @@ def guess_parent_repository(repo_name='.'):
 
 
 def _get_github_repo(config):
-    # TODO: this guessing should be a backup plan; get info from config if
-    # available
+    if "owner" in config and "repo" in config:
+        return config["owner"] + "/" + config["repo"]
+
     owner, repo = guess_parent_repository('.')
     if owner is None or repo is None:
         raise RuntimeError("Unable to determine repository")
@@ -106,10 +107,15 @@ def vendor(resources, base_path, relative_target_dir, substitutions,
                 wfile.write(content)
 
 
-def vendor_actions(base_path, dry=False):
+def vendor_actions(base_path, owner_repo=None, dry=False):
     resources = ['autorelease-default-env.sh', 'autorelease-prep.yml',
                  'autorelease-gh-rel.yml', 'autorelease-deploy.yml']
     resources = ['gh_actions_stages/' + res for res in resources]
     target_dir = pathlib.Path('.github/workflows')
-    substitutions = get_substitution_mapping()
+    if owner_repo:
+        owner, repo = owner_repo.split('/')
+        config = {"owner": owner, "repo": repo}
+    else:
+        config = None
+    substitutions = get_substitution_mapping(config)
     vendor(resources, base_path, target_dir, substitutions, dry=dry)


### PR DESCRIPTION
This allows the user to specify the owner/repo when vendoring, instead of requiring the repo's origin/upstream be registered and therefore guessable.