### PR TITLE
Refactor to avoid duplication of config-file source of metadata

### DIFF
--- a/autorelease/gh_actions_stages/autorelease-gh-rel.yml
+++ b/autorelease/gh_actions_stages/autorelease-gh-rel.yml
@@ -29,8 +29,8 @@ jobs:
           fi
         name: "Install autorelease"
       - run: |
-          VERSION=`python setup.py --version`
-          PROJECT=`python setup.py --name`
+          VERSION=`autorelease metadata version`
+          PROJECT=`autorelease metadata name`
           echo $$PROJECT $$VERSION
           autorelease-release --project $$PROJECT --version $$VERSION --token $$AUTORELEASE_TOKEN
         env:

--- a/autorelease/gh_actions_stages/autorelease-prep.yml
+++ b/autorelease/gh_actions_stages/autorelease-prep.yml
@@ -39,7 +39,7 @@ jobs:
         name: "Install release tools"
       - run: |
           bump-dev-version
-          python setup.py --version
+          autorelease metadata version
         name: "Bump testpypi dev version"
       - run: |
           python setup.py sdist bdist_wheel

--- a/autorelease/scripts/bump_dev_version.py
+++ b/autorelease/scripts/bump_dev_version.py
@@ -66,14 +66,14 @@ def get_version_info(conf_name, index):
     directory, filename = _setup_path_parts(conf_name)
     conf = get_setup_cfg(directory=directory, filename=filename)
     if conf is None:
-        raise RuntimeError("Unable to find setup config: " + conf_name)
+        raise RuntimeError(f"Unable to find setup config: {conf_name}")
 
     v_setup = get_setup_version(None, directory=directory, filename=filename)
     package = get_setup_name(None, directory=directory, filename=filename)
     if v_setup is None:
-        raise RuntimeError("Missing [metadata] version in " + conf_name)
+        raise RuntimeError(f"Missing [metadata] version in {conf_name}")
     if package is None:
-        raise RuntimeError("Missing [metadata] name in " + conf_name)
+        raise RuntimeError(f"Missing [metadata] name in {conf_name}")
     v_pypi = get_latest_pypi(package, index)
     return conf, package, v_setup, v_pypi
 

--- a/autorelease/scripts/bump_dev_version.py
+++ b/autorelease/scripts/bump_dev_version.py
@@ -6,7 +6,9 @@ from json import JSONDecodeError
 from packaging.version import Version
 import requests
 from autorelease.utils import split_setup_cfg_path
-from autorelease.version import get_setup_cfg, get_setup_name, get_setup_version
+from autorelease.version import (
+    ConfigParserError, get_setup_cfg, get_setup_name, get_setup_version
+)
 
 def get_latest_pypi(package, index="https://test.pypi.org/pypi"):
     url = "/".join([index, package, 'json'])
@@ -56,7 +58,12 @@ def shared_parser():
 
 def get_version_info(conf_name, index):
     directory, filename = split_setup_cfg_path(conf_name)
-    conf = get_setup_cfg(directory=directory, filename=filename)
+    try:
+        conf = get_setup_cfg(directory=directory, filename=filename)
+    except ConfigParserError as exc:
+        raise RuntimeError(
+            f"Unable to parse setup config: {conf_name}"
+        ) from exc
     if conf is None:
         raise RuntimeError(f"Unable to find setup config: {conf_name}")
 

--- a/autorelease/scripts/bump_dev_version.py
+++ b/autorelease/scripts/bump_dev_version.py
@@ -1,17 +1,12 @@
 import argparse
+import os
 import time
-
-try:
-    from configparser import ConfigParser, NoSectionError, NoOptionError
-except ImportError:
-    # py2
-    from ConfigParser import ConfigParser, NoSectionError, NoOptionError
-
 
 from json import JSONDecodeError
 
 from packaging.version import Version
 import requests
+from autorelease.version import get_setup_cfg, get_setup_name, get_setup_version
 
 def get_latest_pypi(package, index="https://test.pypi.org/pypi"):
     url = "/".join([index, package, 'json'])
@@ -59,11 +54,26 @@ def shared_parser():
     parser.add_argument('--get-max', action='store_true')
     return parser
 
+def _setup_path_parts(conf_name):
+    directory, filename = os.path.split(conf_name)
+    if directory == "":
+        directory = "."
+    if filename == "":
+        filename = "setup.cfg"
+    return directory, filename
+
 def get_version_info(conf_name, index):
-    conf = ConfigParser()
-    conf.read(conf_name)
-    v_setup = conf.get('metadata', 'version')
-    package = conf.get('metadata', 'name')
+    directory, filename = _setup_path_parts(conf_name)
+    conf = get_setup_cfg(directory=directory, filename=filename)
+    if conf is None:
+        raise RuntimeError("Unable to find setup config: " + conf_name)
+
+    v_setup = get_setup_version(None, directory=directory, filename=filename)
+    package = get_setup_name(None, directory=directory, filename=filename)
+    if v_setup is None:
+        raise RuntimeError("Missing [metadata] version in " + conf_name)
+    if package is None:
+        raise RuntimeError("Missing [metadata] name in " + conf_name)
     v_pypi = get_latest_pypi(package, index)
     return conf, package, v_setup, v_pypi
 

--- a/autorelease/scripts/bump_dev_version.py
+++ b/autorelease/scripts/bump_dev_version.py
@@ -60,8 +60,8 @@ def get_version_info(conf_name, index):
     if conf is None:
         raise RuntimeError(f"Unable to find setup config: {conf_name}")
 
-    v_setup = get_setup_version(None, directory=directory, filename=filename)
-    package = get_setup_name(None, directory=directory, filename=filename)
+    v_setup = get_setup_version(conf, default_version=None)
+    package = get_setup_name(conf, default_name=None)
     if v_setup is None:
         raise RuntimeError(f"Missing [metadata] version in {conf_name}")
     if package is None:

--- a/autorelease/scripts/bump_dev_version.py
+++ b/autorelease/scripts/bump_dev_version.py
@@ -1,11 +1,11 @@
 import argparse
-import os
 import time
 
 from json import JSONDecodeError
 
 from packaging.version import Version
 import requests
+from autorelease.utils import split_setup_cfg_path
 from autorelease.version import get_setup_cfg, get_setup_name, get_setup_version
 
 def get_latest_pypi(package, index="https://test.pypi.org/pypi"):
@@ -54,16 +54,8 @@ def shared_parser():
     parser.add_argument('--get-max', action='store_true')
     return parser
 
-def _setup_path_parts(conf_name):
-    directory, filename = os.path.split(conf_name)
-    if directory == "":
-        directory = "."
-    if filename == "":
-        filename = "setup.cfg"
-    return directory, filename
-
 def get_version_info(conf_name, index):
-    directory, filename = _setup_path_parts(conf_name)
+    directory, filename = split_setup_cfg_path(conf_name)
     conf = get_setup_cfg(directory=directory, filename=filename)
     if conf is None:
         raise RuntimeError(f"Unable to find setup config: {conf_name}")

--- a/autorelease/scripts/cli.py
+++ b/autorelease/scripts/cli.py
@@ -5,7 +5,7 @@ import yaml
 from autorelease.scripts.vendor import vendor_actions
 from autorelease.scripts.check import run_checks
 from autorelease.utils import split_setup_cfg_path
-from autorelease.version import get_setup_name, get_setup_version
+from autorelease.version import get_setup_cfg, get_setup_name, get_setup_version
 # from autorelease import ReleaseNoteWriter
 from autorelease.gh_api4.notes4 import NotesWriter, prs_since_latest_release
 
@@ -89,7 +89,8 @@ def metadata():
               help="setup.cfg file to use")
 def metadata_version(conf):
     directory, filename = split_setup_cfg_path(conf)
-    value = get_setup_version(None, directory=directory, filename=filename)
+    setup_cfg = get_setup_cfg(directory=directory, filename=filename)
+    value = get_setup_version(setup_cfg, default_version=None)
     field = "version"
 
     if value is None:
@@ -104,7 +105,8 @@ def metadata_version(conf):
               help="setup.cfg file to use")
 def metadata_name(conf):
     directory, filename = split_setup_cfg_path(conf)
-    value = get_setup_name(None, directory=directory, filename=filename)
+    setup_cfg = get_setup_cfg(directory=directory, filename=filename)
+    value = get_setup_name(setup_cfg, default_name=None)
     field = "name"
 
     if value is None:

--- a/autorelease/scripts/cli.py
+++ b/autorelease/scripts/cli.py
@@ -4,6 +4,7 @@ import yaml
 
 from autorelease.scripts.vendor import vendor_actions
 from autorelease.scripts.check import run_checks
+from autorelease.version import get_setup_name, get_setup_version
 # from autorelease import ReleaseNoteWriter
 from autorelease.gh_api4.notes4 import NotesWriter, prs_since_latest_release
 
@@ -76,6 +77,49 @@ def auth(auth):
     from pprint import pprint
     auth = load_auth(auth)
     pprint(auth)
+
+def _conf_parts(conf):
+    directory, filename = os.path.split(conf)
+    if directory == "":
+        directory = "."
+    if filename == "":
+        filename = "setup.cfg"
+    return directory, filename
+
+
+@cli.group()
+def metadata():
+    pass
+
+
+@metadata.command(name="version")
+@click.option("-c", "--conf", type=str, default="setup.cfg",
+              help="setup.cfg file to use")
+def metadata_version(conf):
+    directory, filename = _conf_parts(conf)
+    value = get_setup_version(None, directory=directory, filename=filename)
+    field = "version"
+
+    if value is None:
+        raise click.ClickException(
+            "Missing [metadata] " + field + " in " + conf
+        )
+    click.echo(value)
+
+
+@metadata.command(name="name")
+@click.option("-c", "--conf", type=str, default="setup.cfg",
+              help="setup.cfg file to use")
+def metadata_name(conf):
+    directory, filename = _conf_parts(conf)
+    value = get_setup_name(None, directory=directory, filename=filename)
+    field = "name"
+
+    if value is None:
+        raise click.ClickException(
+            "Missing [metadata] " + field + " in " + conf
+        )
+    click.echo(value)
 
 
 @cli.command()

--- a/autorelease/scripts/cli.py
+++ b/autorelease/scripts/cli.py
@@ -5,7 +5,9 @@ import yaml
 from autorelease.scripts.vendor import vendor_actions
 from autorelease.scripts.check import run_checks
 from autorelease.utils import split_setup_cfg_path
-from autorelease.version import get_setup_cfg, get_setup_name, get_setup_version
+from autorelease.version import (
+    ConfigParserError, get_setup_cfg, get_setup_name, get_setup_version
+)
 # from autorelease import ReleaseNoteWriter
 from autorelease.gh_api4.notes4 import NotesWriter, prs_since_latest_release
 
@@ -89,7 +91,12 @@ def metadata():
               help="setup.cfg file to use")
 def metadata_version(conf):
     directory, filename = split_setup_cfg_path(conf)
-    setup_cfg = get_setup_cfg(directory=directory, filename=filename)
+    try:
+        setup_cfg = get_setup_cfg(directory=directory, filename=filename)
+    except ConfigParserError as exc:
+        raise click.ClickException(
+            f"Unable to parse setup config: {conf}"
+        ) from exc
     value = get_setup_version(setup_cfg, default_version=None)
     field = "version"
 
@@ -105,7 +112,12 @@ def metadata_version(conf):
               help="setup.cfg file to use")
 def metadata_name(conf):
     directory, filename = split_setup_cfg_path(conf)
-    setup_cfg = get_setup_cfg(directory=directory, filename=filename)
+    try:
+        setup_cfg = get_setup_cfg(directory=directory, filename=filename)
+    except ConfigParserError as exc:
+        raise click.ClickException(
+            f"Unable to parse setup config: {conf}"
+        ) from exc
     value = get_setup_name(setup_cfg, default_name=None)
     field = "name"
 

--- a/autorelease/scripts/cli.py
+++ b/autorelease/scripts/cli.py
@@ -4,6 +4,7 @@ import yaml
 
 from autorelease.scripts.vendor import vendor_actions
 from autorelease.scripts.check import run_checks
+from autorelease.utils import split_setup_cfg_path
 from autorelease.version import get_setup_name, get_setup_version
 # from autorelease import ReleaseNoteWriter
 from autorelease.gh_api4.notes4 import NotesWriter, prs_since_latest_release
@@ -78,15 +79,6 @@ def auth(auth):
     auth = load_auth(auth)
     pprint(auth)
 
-def _conf_parts(conf):
-    directory, filename = os.path.split(conf)
-    if directory == "":
-        directory = "."
-    if filename == "":
-        filename = "setup.cfg"
-    return directory, filename
-
-
 @cli.group()
 def metadata():
     pass
@@ -96,7 +88,7 @@ def metadata():
 @click.option("-c", "--conf", type=str, default="setup.cfg",
               help="setup.cfg file to use")
 def metadata_version(conf):
-    directory, filename = _conf_parts(conf)
+    directory, filename = split_setup_cfg_path(conf)
     value = get_setup_version(None, directory=directory, filename=filename)
     field = "version"
 
@@ -111,7 +103,7 @@ def metadata_version(conf):
 @click.option("-c", "--conf", type=str, default="setup.cfg",
               help="setup.cfg file to use")
 def metadata_name(conf):
-    directory, filename = _conf_parts(conf)
+    directory, filename = split_setup_cfg_path(conf)
     value = get_setup_name(None, directory=directory, filename=filename)
     field = "name"
 

--- a/autorelease/scripts/cli.py
+++ b/autorelease/scripts/cli.py
@@ -97,6 +97,10 @@ def metadata_version(conf):
         raise click.ClickException(
             f"Unable to parse setup config: {conf}"
         ) from exc
+    if setup_cfg is None:
+        raise click.ClickException(
+            f"Unable to find setup config: {conf}"
+        )
     value = get_setup_version(setup_cfg, default_version=None)
     field = "version"
 
@@ -118,6 +122,10 @@ def metadata_name(conf):
         raise click.ClickException(
             f"Unable to parse setup config: {conf}"
         ) from exc
+    if setup_cfg is None:
+        raise click.ClickException(
+            f"Unable to find setup config: {conf}"
+        )
     value = get_setup_name(setup_cfg, default_name=None)
     field = "name"
 

--- a/autorelease/scripts/cli.py
+++ b/autorelease/scripts/cli.py
@@ -102,7 +102,7 @@ def metadata_version(conf):
 
     if value is None:
         raise click.ClickException(
-            "Missing [metadata] " + field + " in " + conf
+            f"Missing [metadata] {field} in {conf}"
         )
     click.echo(value)
 
@@ -117,7 +117,7 @@ def metadata_name(conf):
 
     if value is None:
         raise click.ClickException(
-            "Missing [metadata] " + field + " in " + conf
+            f"Missing [metadata] {field} in {conf}"
         )
     click.echo(value)
 

--- a/autorelease/tests/test_bump_dev_version.py
+++ b/autorelease/tests/test_bump_dev_version.py
@@ -57,3 +57,17 @@ def test_get_version_info_reuses_loaded_conf(tmp_path, monkeypatch):
     assert package == "mypkg"
     assert v_setup == "1.2.3.dev0"
     assert v_pypi == "1.2.2"
+
+
+def test_get_version_info_malformed_cfg(tmp_path):
+    setup_cfg = tmp_path / "setup.cfg"
+    setup_cfg.write_text(
+        "[metadata\n"
+        "name = badpkg\n"
+        "version = 0.0.0\n"
+    )
+
+    with pytest.raises(RuntimeError, match="Unable to parse setup config"):
+        bump_mod.get_version_info(
+            str(setup_cfg), "https://example.invalid/pypi"
+        )

--- a/autorelease/tests/test_bump_dev_version.py
+++ b/autorelease/tests/test_bump_dev_version.py
@@ -1,5 +1,7 @@
 import pytest
 from autorelease.scripts.bump_dev_version import *
+import autorelease.scripts.bump_dev_version as bump_mod
+import autorelease.version as version_mod
 
 def test_shared_parser():
     parser = shared_parser()
@@ -22,3 +24,36 @@ def test_select_version(v_pypi, v_setup, expected):
 ])
 def test_bump_dev_version(version_str, expected):
     assert bump_dev_version(version_str) == expected
+
+
+def test_get_version_info_reuses_loaded_conf(tmp_path, monkeypatch):
+    setup_cfg = tmp_path / "setup.cfg"
+    setup_cfg.write_text(
+        "[metadata]\n"
+        "name = mypkg\n"
+        "version = 1.2.3.dev0\n"
+    )
+
+    real_get_setup_cfg = bump_mod.get_setup_cfg
+    calls = {"count": 0}
+
+    def counted_get_setup_cfg(*args, **kwargs):
+        calls["count"] += 1
+        return real_get_setup_cfg(*args, **kwargs)
+
+    def unexpected_get_setup_cfg(*args, **kwargs):
+        raise AssertionError("setup.cfg was reloaded")
+
+    monkeypatch.setattr(bump_mod, "get_setup_cfg", counted_get_setup_cfg)
+    monkeypatch.setattr(version_mod, "get_setup_cfg", unexpected_get_setup_cfg)
+    monkeypatch.setattr(bump_mod, "get_latest_pypi", lambda *args: "1.2.2")
+
+    conf, package, v_setup, v_pypi = bump_mod.get_version_info(
+        str(setup_cfg), "https://example.invalid/pypi"
+    )
+
+    assert calls["count"] == 1
+    assert conf.get("metadata", "name") == "mypkg"
+    assert package == "mypkg"
+    assert v_setup == "1.2.3.dev0"
+    assert v_pypi == "1.2.2"

--- a/autorelease/tests/test_cli.py
+++ b/autorelease/tests/test_cli.py
@@ -1,0 +1,118 @@
+from click.testing import CliRunner
+
+import autorelease.scripts.cli as cli_mod
+
+
+def test_metadata_version(monkeypatch):
+    monkeypatch.setattr(
+        cli_mod, "get_setup_version",
+        lambda _conf, default_version=None: "1.2.3"
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["metadata", "version"])
+    assert result.exit_code == 0
+    assert result.output.strip() == "1.2.3"
+
+
+def test_metadata_name(monkeypatch):
+    monkeypatch.setattr(
+        cli_mod, "get_setup_name",
+        lambda _conf, default_name=None: "mypackage"
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, ["metadata", "name"])
+    assert result.exit_code == 0
+    assert result.output.strip() == "mypackage"
+
+
+def test_metadata_cli_name_and_version(tmp_path):
+    setup_cfg = tmp_path / "setup.cfg"
+    setup_cfg.write_text(
+        "[metadata]\n"
+        "name = mypkg\n"
+        "version = 1.2.3.dev0\n"
+    )
+
+    runner = CliRunner()
+    name_result = runner.invoke(
+        cli_mod.cli, ["metadata", "name", "--conf", str(setup_cfg)]
+    )
+    version_result = runner.invoke(
+        cli_mod.cli, ["metadata", "version", "--conf", str(setup_cfg)]
+    )
+
+    assert name_result.exit_code == 0
+    assert name_result.output == "mypkg\n"
+    assert version_result.exit_code == 0
+    assert version_result.output == "1.2.3.dev0\n"
+
+
+def test_metadata_cli_missing_file(tmp_path):
+    missing_cfg = tmp_path / "missing.cfg"
+    runner = CliRunner()
+
+    name_result = runner.invoke(
+        cli_mod.cli, ["metadata", "name", "--conf", str(missing_cfg)]
+    )
+    version_result = runner.invoke(
+        cli_mod.cli, ["metadata", "version", "--conf", str(missing_cfg)]
+    )
+
+    assert name_result.exit_code != 0
+    assert f"Unable to find setup config: {missing_cfg}" in name_result.output
+    assert version_result.exit_code != 0
+    assert f"Unable to find setup config: {missing_cfg}" in version_result.output
+
+
+def test_metadata_cli_missing_fields(tmp_path):
+    no_name_cfg = tmp_path / "setup_no_name.cfg"
+    no_name_cfg.write_text(
+        "[metadata]\n"
+        "version = 2.0.0\n"
+    )
+    no_version_cfg = tmp_path / "setup_no_version.cfg"
+    no_version_cfg.write_text(
+        "[metadata]\n"
+        "name = pkg-without-version\n"
+    )
+
+    runner = CliRunner()
+    missing_name_result = runner.invoke(
+        cli_mod.cli, ["metadata", "name", "--conf", str(no_name_cfg)]
+    )
+    missing_version_result = runner.invoke(
+        cli_mod.cli, ["metadata", "version", "--conf", str(no_version_cfg)]
+    )
+
+    assert missing_name_result.exit_code != 0
+    assert f"Missing [metadata] name in {no_name_cfg}" in missing_name_result.output
+    assert missing_version_result.exit_code != 0
+    assert (
+        f"Missing [metadata] version in {no_version_cfg}"
+        in missing_version_result.output
+    )
+
+
+def test_metadata_cli_malformed_cfg(tmp_path):
+    setup_cfg = tmp_path / "setup.cfg"
+    setup_cfg.write_text(
+        "[metadata\n"
+        "name = badpkg\n"
+        "version = 0.0.0\n"
+    )
+
+    runner = CliRunner()
+    name_result = runner.invoke(
+        cli_mod.cli, ["metadata", "name", "--conf", str(setup_cfg)]
+    )
+    version_result = runner.invoke(
+        cli_mod.cli, ["metadata", "version", "--conf", str(setup_cfg)]
+    )
+
+    assert name_result.exit_code != 0
+    assert f"Unable to parse setup config: {setup_cfg}" in name_result.output
+    assert version_result.exit_code != 0
+    assert (
+        f"Unable to parse setup config: {setup_cfg}"
+        in version_result.output
+    )

--- a/autorelease/tests/test_version.py
+++ b/autorelease/tests/test_version.py
@@ -4,7 +4,9 @@ from unittest import mock
 import os
 
 
-from autorelease.version import _find_rel_path_for_file
+from autorelease.version import (
+    _find_rel_path_for_file, get_setup_name, get_setup_version
+)
 
 @pytest.mark.parametrize("depth, result", [
     (0, '.'), (1, '..'), (2, '..' + os.sep + '..'),
@@ -25,3 +27,13 @@ def test_find_rel_path_for_file_finds_no_file():
     with mock.patch('autorelease.version.os.path.isfile', lambda x: False):
         assert _find_rel_path_for_file(-1, 'setup.cfg') is None
 
+
+def test_get_setup_name_and_version(tmp_path):
+    setup_cfg = tmp_path / "setup.cfg"
+    setup_cfg.write_text(
+        "[metadata]\n"
+        "name = mypkg\n"
+        "version = 1.2.3.dev0\n"
+    )
+    assert get_setup_name(None, str(tmp_path), "setup.cfg") == "mypkg"
+    assert get_setup_version(None, str(tmp_path), "setup.cfg") == "1.2.3.dev0"

--- a/autorelease/tests/test_version.py
+++ b/autorelease/tests/test_version.py
@@ -5,7 +5,7 @@ import os
 
 
 from autorelease.version import (
-    _find_rel_path_for_file, get_setup_name, get_setup_version
+    _find_rel_path_for_file, get_setup_cfg, get_setup_name, get_setup_version
 )
 
 @pytest.mark.parametrize("depth, result", [
@@ -35,15 +35,19 @@ def test_get_setup_name_and_version(tmp_path):
         "name = mypkg\n"
         "version = 1.2.3.dev0\n"
     )
-    assert get_setup_name(None, str(tmp_path), "setup.cfg") == "mypkg"
-    assert get_setup_version(None, str(tmp_path), "setup.cfg") == "1.2.3.dev0"
+    conf = get_setup_cfg(str(tmp_path), "setup.cfg")
+    assert get_setup_name(conf, default_name=None) == "mypkg"
+    assert get_setup_version(conf, default_version=None) == "1.2.3.dev0"
 
 
 def test_get_setup_name_and_version_missing_file(tmp_path):
     default_name = "default-name"
     default_version = "0.0.0"
-    assert get_setup_name(default_name, str(tmp_path), "setup.cfg") == default_name
-    assert get_setup_version(default_version, str(tmp_path), "setup.cfg") == default_version
+    conf = get_setup_cfg(str(tmp_path), "setup.cfg")
+    assert get_setup_name(conf, default_name=default_name) == default_name
+    assert get_setup_version(
+        conf, default_version=default_version
+    ) == default_version
 
 
 def test_get_setup_name_and_version_missing_fields(tmp_path):
@@ -52,16 +56,26 @@ def test_get_setup_name_and_version_missing_fields(tmp_path):
         "[metadata]\n"
         "version = 2.0.0\n"
     )
-    assert get_setup_name("default-name", str(tmp_path), "setup_no_name.cfg") == "default-name"
-    assert get_setup_version(None, str(tmp_path), "setup_no_name.cfg") == "2.0.0"
+    conf_no_name = get_setup_cfg(str(tmp_path), "setup_no_name.cfg")
+    assert get_setup_name(
+        conf_no_name, default_name="default-name"
+    ) == "default-name"
+    assert get_setup_version(
+        conf_no_name, default_version=None
+    ) == "2.0.0"
 
     setup_cfg_no_version = tmp_path / "setup_no_version.cfg"
     setup_cfg_no_version.write_text(
         "[metadata]\n"
         "name = pkg-without-version\n"
     )
-    assert get_setup_version("0.0.0", str(tmp_path), "setup_no_version.cfg") == "0.0.0"
-    assert get_setup_name(None, str(tmp_path), "setup_no_version.cfg") == "pkg-without-version"
+    conf_no_version = get_setup_cfg(str(tmp_path), "setup_no_version.cfg")
+    assert get_setup_version(
+        conf_no_version, default_version="0.0.0"
+    ) == "0.0.0"
+    assert get_setup_name(
+        conf_no_version, default_name=None
+    ) == "pkg-without-version"
 
 
 def test_get_setup_name_and_version_malformed_cfg(tmp_path):
@@ -72,5 +86,6 @@ def test_get_setup_name_and_version_malformed_cfg(tmp_path):
         "version = 0.0.0\n"
     )
 
-    assert get_setup_name("default-name", str(tmp_path), "setup.cfg") == "default-name"
-    assert get_setup_version("0.0.0", str(tmp_path), "setup.cfg") == "0.0.0"
+    conf = get_setup_cfg(str(tmp_path), "setup.cfg")
+    assert get_setup_name(conf, default_name="default-name") == "default-name"
+    assert get_setup_version(conf, default_version="0.0.0") == "0.0.0"

--- a/autorelease/tests/test_version.py
+++ b/autorelease/tests/test_version.py
@@ -37,3 +37,40 @@ def test_get_setup_name_and_version(tmp_path):
     )
     assert get_setup_name(None, str(tmp_path), "setup.cfg") == "mypkg"
     assert get_setup_version(None, str(tmp_path), "setup.cfg") == "1.2.3.dev0"
+
+
+def test_get_setup_name_and_version_missing_file(tmp_path):
+    default_name = "default-name"
+    default_version = "0.0.0"
+    assert get_setup_name(default_name, str(tmp_path), "setup.cfg") == default_name
+    assert get_setup_version(default_version, str(tmp_path), "setup.cfg") == default_version
+
+
+def test_get_setup_name_and_version_missing_fields(tmp_path):
+    setup_cfg_no_name = tmp_path / "setup_no_name.cfg"
+    setup_cfg_no_name.write_text(
+        "[metadata]\n"
+        "version = 2.0.0\n"
+    )
+    assert get_setup_name("default-name", str(tmp_path), "setup_no_name.cfg") == "default-name"
+    assert get_setup_version(None, str(tmp_path), "setup_no_name.cfg") == "2.0.0"
+
+    setup_cfg_no_version = tmp_path / "setup_no_version.cfg"
+    setup_cfg_no_version.write_text(
+        "[metadata]\n"
+        "name = pkg-without-version\n"
+    )
+    assert get_setup_version("0.0.0", str(tmp_path), "setup_no_version.cfg") == "0.0.0"
+    assert get_setup_name(None, str(tmp_path), "setup_no_version.cfg") == "pkg-without-version"
+
+
+def test_get_setup_name_and_version_malformed_cfg(tmp_path):
+    setup_cfg = tmp_path / "setup.cfg"
+    setup_cfg.write_text(
+        "[metadata\n"
+        "name = badpkg\n"
+        "version = 0.0.0\n"
+    )
+
+    assert get_setup_name("default-name", str(tmp_path), "setup.cfg") == "default-name"
+    assert get_setup_version("0.0.0", str(tmp_path), "setup.cfg") == "0.0.0"

--- a/autorelease/tests/test_version.py
+++ b/autorelease/tests/test_version.py
@@ -5,7 +5,8 @@ import os
 
 
 from autorelease.version import (
-    _find_rel_path_for_file, get_setup_cfg, get_setup_name, get_setup_version
+    ConfigParserError, _find_rel_path_for_file, get_setup_cfg,
+    get_setup_name, get_setup_version
 )
 
 @pytest.mark.parametrize("depth, result", [
@@ -86,6 +87,5 @@ def test_get_setup_name_and_version_malformed_cfg(tmp_path):
         "version = 0.0.0\n"
     )
 
-    conf = get_setup_cfg(str(tmp_path), "setup.cfg")
-    assert get_setup_name(conf, default_name="default-name") == "default-name"
-    assert get_setup_version(conf, default_version="0.0.0") == "0.0.0"
+    with pytest.raises(ConfigParserError):
+        get_setup_cfg(str(tmp_path), "setup.cfg")

--- a/autorelease/utils.py
+++ b/autorelease/utils.py
@@ -1,9 +1,9 @@
-import yaml
 import re
 import os
 import sys
 
 def conda_recipe_version(recipe_file):
+    import yaml
     with open(recipe_file) as f:
         dct = yaml.load(f.read(), Loader=yaml.FullLoader)
     return dct['package']['version']
@@ -35,3 +35,12 @@ def _import_setup_py3(directory):
     setup = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(setup)
     return setup
+
+
+def split_setup_cfg_path(conf_name):
+    directory, filename = os.path.split(conf_name)
+    if directory == "":
+        directory = "."
+    if filename == "":
+        filename = "setup.cfg"
+    return directory, filename

--- a/autorelease/version.py
+++ b/autorelease/version.py
@@ -3,10 +3,14 @@ import os
 import subprocess
 
 try:
-    from configparser import ConfigParser, NoSectionError, NoOptionError
+    from configparser import (
+        ConfigParser, Error as ConfigParserError, NoSectionError, NoOptionError
+    )
 except ImportError:
     # py2
-    from ConfigParser import ConfigParser, NoSectionError, NoOptionError
+    from ConfigParser import (
+        ConfigParser, Error as ConfigParserError, NoSectionError, NoOptionError
+    )
 
 try:
     from ._installed_version import _installed_version
@@ -109,13 +113,31 @@ def get_setup_cfg(directory, filename="setup.cfg"):
     conf = None
     if os.path.exists(setup_cfg):
         conf = ConfigParser()
-        conf.read(setup_cfg)
+        try:
+            conf.read(setup_cfg)
+        except ConfigParserError:
+            conf = None
 
     return conf
 
 
 def get_setup_value(default_value, directory, option, section='metadata',
                     filename="setup.cfg"):
+    """Get a setup.cfg value or return the provided default.
+
+    Parameters
+    ----------
+    default_value
+        value to return when setup.cfg is missing or does not define field
+    directory : str or int
+        directory for setup.cfg (or search depth if int)
+    option : str
+        field name to retrieve from section
+    section : str
+        section name to query; default 'metadata'
+    filename : str
+        filename for setup.cfg; default 'setup.cfg'
+    """
     value = default_value
     conf = get_setup_cfg(directory, filename)
     try:

--- a/autorelease/version.py
+++ b/autorelease/version.py
@@ -114,16 +114,29 @@ def get_setup_cfg(directory, filename="setup.cfg"):
     return conf
 
 
-def get_setup_version(default_version, directory, filename="setup.cfg"):
-    version = default_version
+def get_setup_value(default_value, directory, option, section='metadata',
+                    filename="setup.cfg"):
+    value = default_value
     conf = get_setup_cfg(directory, filename)
     try:
-        version = conf.get('metadata', 'version')
+        value = conf.get(section, option)
     except (NoSectionError, NoOptionError):
-        pass  # version (or metadata) not defined in setup.cfg
+        pass  # option (or section) not defined in setup.cfg
     except AttributeError:
         pass  # no setup.cfg found (conf is None)
-    return version
+    return value
+
+
+def get_setup_version(default_version, directory, filename="setup.cfg"):
+    return get_setup_value(default_version, directory=directory,
+                           option='version', section='metadata',
+                           filename=filename)
+
+
+def get_setup_name(default_name, directory, filename="setup.cfg"):
+    return get_setup_value(default_name, directory=directory,
+                           option='name', section='metadata',
+                           filename=filename)
 
 
 short_version = get_setup_version(_installed_version,

--- a/autorelease/version.py
+++ b/autorelease/version.py
@@ -121,25 +121,21 @@ def get_setup_cfg(directory, filename="setup.cfg"):
     return conf
 
 
-def get_setup_value(default_value, directory, option, section='metadata',
-                    filename="setup.cfg"):
+def get_setup_value(conf, option, default=None, section='metadata'):
     """Get a setup.cfg value or return the provided default.
 
     Parameters
     ----------
-    default_value
-        value to return when setup.cfg is missing or does not define field
-    directory : str or int
-        directory for setup.cfg (or search depth if int)
+    conf : ConfigParser
+        loaded setup.cfg content to query
     option : str
         field name to retrieve from section
+    default
+        value to return when setup.cfg is missing or does not define field
     section : str
         section name to query; default 'metadata'
-    filename : str
-        filename for setup.cfg; default 'setup.cfg'
     """
-    value = default_value
-    conf = get_setup_cfg(directory, filename)
+    value = default
     try:
         value = conf.get(section, option)
     except (NoSectionError, NoOptionError):
@@ -149,20 +145,20 @@ def get_setup_value(default_value, directory, option, section='metadata',
     return value
 
 
-def get_setup_version(default_version, directory, filename="setup.cfg"):
-    return get_setup_value(default_version, directory=directory,
-                           option='version', section='metadata',
-                           filename=filename)
+def get_setup_version(conf, default_version=None):
+    return get_setup_value(conf, option='version', section='metadata',
+                           default=default_version)
 
 
-def get_setup_name(default_name, directory, filename="setup.cfg"):
-    return get_setup_value(default_name, directory=directory,
-                           option='name', section='metadata',
-                           filename=filename)
+def get_setup_name(conf, default_name=None):
+    return get_setup_value(conf, option='name', section='metadata',
+                           default=default_name)
 
 
-short_version = get_setup_version(_installed_version,
-                                  directory=_version_setup_depth)
+short_version = get_setup_version(
+    get_setup_cfg(directory=_version_setup_depth),
+    default_version=_installed_version,
+)
 _git_version = get_git_version()
 _is_repo = (_git_version != '' and _git_version != "Unknown")
 

--- a/autorelease/version.py
+++ b/autorelease/version.py
@@ -102,6 +102,11 @@ def get_setup_cfg(directory, filename="setup.cfg"):
         directory for setup.cfg, relative to cwd; default '.'
     filename : str
         filename for setup.cfg; default 'setup.cfg'
+
+    Raises
+    ------
+    ConfigParserError
+        if setup.cfg exists but cannot be parsed
     """
     if isinstance(directory, int):
         rel_path = _find_rel_path_for_file(directory, filename)
@@ -113,10 +118,7 @@ def get_setup_cfg(directory, filename="setup.cfg"):
     conf = None
     if os.path.exists(setup_cfg):
         conf = ConfigParser()
-        try:
-            conf.read(setup_cfg)
-        except ConfigParserError:
-            conf = None
+        conf.read(setup_cfg)
 
     return conf
 

--- a/autorelease/version.py
+++ b/autorelease/version.py
@@ -94,14 +94,19 @@ def _find_rel_path_for_file(depth, filename):
 
 
 def get_setup_cfg(directory, filename="setup.cfg"):
-    """Load the setup.cfg as a dict-of-dict.
+    """Load and parse setup.cfg.
 
     Parameters
     ----------
-    directory : str
-        directory for setup.cfg, relative to cwd; default '.'
+    directory : str or int
+        directory for setup.cfg, relative to cwd; or search depth if int
     filename : str
         filename for setup.cfg; default 'setup.cfg'
+
+    Returns
+    -------
+    ConfigParser or None
+        parsed setup.cfg if the file exists; otherwise None
 
     Raises
     ------

--- a/autorelease/version_checks.py
+++ b/autorelease/version_checks.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import re
 import packaging.version as vers
 
-from autorelease.version import get_setup_version  # reuse the vendored
+from autorelease.version import get_setup_cfg, get_setup_version
 from autorelease.utils import conda_recipe_version
 
 import importlib
@@ -17,7 +17,9 @@ def import_and_get(fully_qualified):
 
 
 version_getters = {
-    'setup-cfg': lambda path: get_setup_version(None, path),
+    'setup-cfg': lambda path: get_setup_version(
+        get_setup_cfg(path), default_version=None
+    ),
     'conda': conda_recipe_version,
     'getattr': import_and_get,
 }

--- a/release_check.py
+++ b/release_check.py
@@ -7,10 +7,10 @@ import setup
 #import contact_map
 from packaging.version import Version
 from autorelease import DefaultCheckRunner, conda_recipe_version
-from autorelease.version import get_setup_version
+from autorelease.version import get_setup_cfg, get_setup_version
 
 repo_path = '.'
-SETUP_VERSION = get_setup_version(None, directory='.')
+SETUP_VERSION = get_setup_version(get_setup_cfg('.'), default_version=None)
 versions = {
     #'package': contact_map.version.version,
     'setup.py': SETUP_VERSION,

--- a/script_stages/deploy-pypi
+++ b/script_stages/deploy-pypi
@@ -5,7 +5,7 @@ EXTRA_TWINE_ARGS="$@"
 python -m pip install twine wheel
 
 bump-dev-version
-python setup.py --version
+autorelease metadata version
 python setup.py sdist bdist_wheel
 
 twine check dist/* || exit 1

--- a/script_stages/install-testpypi
+++ b/script_stages/install-testpypi
@@ -4,7 +4,7 @@ if [ -z "$DRY" ]; then
     wait-for-testpypi
 fi
 
-export PROJECT=`python setup.py --name`
+export PROJECT=`autorelease metadata name`
 export VERSION=`pypi-max-version $PROJECT`
 echo "Installing ${PROJECT}==${VERSION} (allowing pre-releases)"
 if [ -z "$DRY" ]; then


### PR DESCRIPTION
This is intended to make it so we have a single source of truth for some metadata we usually get from the config file (package-defined version; package name) and that we also expose that as CLI commands to be used in scripts.

--- 

This pull request refactors how project metadata (specifically the name and version) is retrieved throughout the autorelease workflow. Instead of directly parsing `setup.cfg` using `setup.py` or custom code, new CLI commands are introduced to robustly fetch these fields, and supporting utility functions are added and tested. This improves reliability, consistency, and maintainability across scripts and CI pipelines.

**Core infrastructure improvements:**

* Added `autorelease metadata name` and `autorelease metadata version` CLI commands to reliably fetch the project name and version from `setup.cfg`, replacing previous ad hoc parsing and direct `python setup.py` calls. (`autorelease/scripts/cli.py`, [autorelease/scripts/cli.pyR81-R123](diffhunk://#diff-90b4780b73be1d4841766a29bd882ef29500ec25df5bce627456912a0eab60c8R81-R123))
* Refactored utility functions in `autorelease/version.py` to generalize fetching arbitrary metadata fields, and added dedicated `get_setup_name` and `get_setup_version` helpers. (`autorelease/version.py`, [autorelease/version.pyL117-R139](diffhunk://#diff-6e01962f1d2bc3c72082f4023a7d3216891b8337349b7c48d96097babc6913eeL117-R139))
* Updated tests to cover the new metadata extraction functions for both name and version. (`autorelease/tests/test_version.py`, [autorelease/tests/test_version.pyR30-R39](diffhunk://#diff-2de91d084460de1d1070ed0dc4c1fea1105c764b50715220660366183ca50c82R30-R39))

**CI/CD and script updates:**

* Updated all CI/CD scripts and jobs to use the new `autorelease metadata` commands instead of `python setup.py` for retrieving project name and version. (`autorelease/gh_actions_stages/autorelease-gh-rel.yml`, [[1]](diffhunk://#diff-ffe82cbd9b6563b06ab80db3132037343a67c2173ac9a502dd1de65665273541L32-R33); `autorelease/gh_actions_stages/autorelease-prep.yml`, [[2]](diffhunk://#diff-3cd31aeed11316008bf107a706541c600b1d72b75205ed8e2c1b826fe7ceb6f9L42-R42); `script_stages/deploy-pypi`, [[3]](diffhunk://#diff-363ceef0a10d0db6b90f4a9610ed8cbefa7973591c37feba0571af1e9fb41c34L8-R8); `script_stages/install-testpypi`, [[4]](diffhunk://#diff-03d14bcafaaea2923320d15f4a29699668c89a6d3148e3a7d0ec06c39ba9ffeeL7-R7)

**Internal code cleanup:**

* Refactored `bump_dev_version.py` to use the new shared metadata extraction logic, removing duplicated config parsing code. (`autorelease/scripts/bump_dev_version.py`, [[1]](diffhunk://#diff-b8a21f052cf2bd4f61d8ed250564f4754431dbce55e861510d9a82cbc626ae34R2-R9) [[2]](diffhunk://#diff-b8a21f052cf2bd4f61d8ed250564f4754431dbce55e861510d9a82cbc626ae34R57-R76)